### PR TITLE
add BUILD file for grpc

### DIFF
--- a/stats/BUILD
+++ b/stats/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2017, Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Description:
+#   Open source Census protos.
+
+package(default_visibility = ["#visibility:public"])
+
+load("@submodule_grpc#bazel:grpc_build_system.bzl", "grpc_proto_library")
+
+grpc_proto_library(
+      name = "census",
+      srcs = [
+          "census.proto",
+      ],
+      use_external = True,
+)


### PR DESCRIPTION
Add bazel rule to generate census proto library that can be used by
other repos that use gRPC.