### PR TITLE
Re-uses grpc approach for implicit protoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,34 @@
     </license>
   </licenses>
 
+  <properties>
+    <!-- for dynamically installing protoc -->
+    <grpc.version>1.6.1</grpc.version>
+    <protobuf.version>3.4.0</protobuf.version>
+  </properties>
+
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.0</version>
         <configuration>
-          <protocExecutable>protoc</protocExecutable>
+          <!--
+            The version of protoc must match protobuf-java. If you don't depend on
+            protobuf-java directly, you will be transitively depending on the
+            protobuf-java version that grpc depends on.
+          -->
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
           <protoSourceRoot>.</protoSourceRoot>
 	  <includes>
             <include>stats/*.proto</include>
@@ -46,7 +66,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.1</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -58,7 +78,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.4.0</version>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
By borrowing grpc's protoc, users have less build steps. We use the same
in Brave.