### PR TITLE
Rename NetworkEvents to MessageEvents

### DIFF
--- a/trace/trace.proto
+++ b/trace/trace.proto
@@ -105,38 +105,31 @@ message Span {
       Attributes attributes = 2;
     }
 
-    // An event describing an RPC message sent or received on the network.
-    message NetworkEvent {
-      // For sent messages, this is the time at which the first bit was sent.
-      // For received messages, this is the time at which the last bit was
-      // received.
-      google.protobuf.Timestamp time = 1;
-
-      // Indicates whether the network message was sent or received.
+    // An event describing a message sent/received between Spans.
+    message MessageEvent {
+      // Indicates whether the message was sent or received.
       enum Type {
         // Unknown event type.
         TYPE_UNSPECIFIED = 0;
-        // Indicates a sent RPC message.
+        // Indicates a sent message.
         SENT = 1;
-        // Indicates a received RPC message.
-        RECV = 2;
+        // Indicates a received message.
+        RECEIVED = 2;
       }
 
-      // Type of NetworkEvent. Indicates whether the RPC message was sent or
+      // Type of MessageEvent. Indicates whether the message was sent or
       // received.
-      Type type = 2;
+      Type type = 1;
 
-      // An identifier for the message, which must be unique in this span and
-      // the same between RECV and SENT (this allows to identify a message
-      // between the sender and receiver). For example, this could be a
-      // sequence id.
-      uint64 message_id = 3;
+      // An identifier for the message, which must be unique in this span.
+      uint64 id = 2;
 
       // The number of uncompressed bytes sent or received.
-      uint64 uncompressed_message_size = 4;
+      uint64 uncompressed_size = 3;
 
-      // The number of compressed bytes sent or received.
-      uint64 compressed_message_size = 5;
+      // The number of compressed bytes sent or received. If missing assumed to
+      // be the same size as uncompressed.
+      uint64 compressed_size = 4;
     }
 
     // A `TimeEvent` can contain either an `Annotation` object or a
@@ -146,7 +139,7 @@ message Span {
       Annotation annotation = 2;
 
       // An event describing an RPC message sent/received on the network.
-      NetworkEvent network_event = 3;
+      MessageEvent network_event = 3;
     }
   }
 
@@ -163,7 +156,7 @@ message Span {
 
     // The number of dropped network events in all the included time events.
     // If the value is 0, then no network events were dropped.
-    int32 dropped_network_events_count = 3;
+    int32 dropped_message_events_count = 3;
   }
 
   // The included time events.

--- a/trace/trace.proto
+++ b/trace/trace.proto
@@ -121,7 +121,10 @@ message Span {
       // received.
       Type type = 1;
 
-      // An identifier for the message, which must be unique in this span.
+      // An identifier for the MessageEvent's message that can be used to match
+      // SENT and RECEIVED MessageEvents. For example, this field could
+      // represent a sequence id for a streaming RPC. It is recommended to be
+      // unique within a Span.
       uint64 id = 2;
 
       // The number of uncompressed bytes sent or received.

--- a/trace/trace.proto
+++ b/trace/trace.proto
@@ -91,7 +91,7 @@ message Span {
   // Stack trace captured at the start of the span.
   StackTrace stack_trace = 8;
 
-  // A time-stamped annotation or network event in the Span.
+  // A time-stamped annotation or message event in the Span.
   message TimeEvent {
     // The timestamp indicating the time the event occurred.
     google.protobuf.Timestamp time = 1;
@@ -133,19 +133,19 @@ message Span {
     }
 
     // A `TimeEvent` can contain either an `Annotation` object or a
-    // `NetworkEvent` object, but not both.
+    // `MessageEvent` object, but not both.
     oneof value {
       // Text annotation with a set of attributes.
       Annotation annotation = 2;
 
-      // An event describing an RPC message sent/received on the network.
-      MessageEvent network_event = 3;
+      // An event describing a message sent/received between Spans.
+      MessageEvent message_event = 3;
     }
   }
 
   // A collection of `TimeEvent`s. A `TimeEvent` is a time-stamped annotation
   // on the span, consisting of either user-supplied key:value pairs, or
-  // details of an RPC message sent/received on the network.
+  // details of a message sent/received between Spans.
   message TimeEvents {
     // A collection of `TimeEvent`s.
     repeated TimeEvent time_event = 1;
@@ -154,8 +154,8 @@ message Span {
     // If the value is 0, then no annotations were dropped.
     int32 dropped_annotations_count = 2;
 
-    // The number of dropped network events in all the included time events.
-    // If the value is 0, then no network events were dropped.
+    // The number of dropped message events in all the included time events.
+    // If the value is 0, then no message events were dropped.
     int32 dropped_message_events_count = 3;
   }
 


### PR DESCRIPTION
Changes in this PR:
1) Rename NetworkEvents to MessageEvents;
2) Remove "message" from all the internal fields of the newly "MessageEvent" because the "message" is redundant.
3) Remove kernel timestamp for the moment because that is not generic enough to be used in MessageEvents (we can always add it later).

This is to allow us to use MessageEvents in pipeline works, in-process biderctional streams, or in batch processing and not force to have an RPC when we record them.