### PR TITLE
Add Span kind to the Span.

### DIFF
--- a/opencensus/proto/trace/trace.proto
+++ b/opencensus/proto/trace/trace.proto
@@ -31,6 +31,8 @@ option go_package = "traceproto";
 // its sub-operations. A trace can also contain multiple root spans,
 // or none at all. Spans do not need to be contiguous - there may be
 // gaps or overlaps between spans in a trace.
+//
+// The next id is 15.
 // TODO(bdrutu): Add an example.
 message Span {
   // A unique identifier for a trace. All spans from the same trace share
@@ -58,6 +60,26 @@ message Span {
   //
   // This field is required.
   TruncatableString name = 4;
+
+  // Type of span. Can be used to specify additional relationships between spans
+  // in addition to a parent/child relationship.
+  enum SpanKind {
+    // Unspecified.
+    SPAN_KIND_UNSPECIFIED = 0;
+
+    // Indicates that the span covers server-side handling of an RPC or other
+    // remote network request.
+    SERVER = 1;
+
+    // Indicates that the span covers the client-side wrapper around an RPC or
+    // other remote request.
+    CLIENT = 2;
+  }
+
+  // Distinguishes between spans generated in a particular context. For example,
+  // two spans with the same name may be distinguished using `CLIENT`
+  // and `SERVER` to identify queueing latency associated with the span.
+  SpanKind kind = 14;
 
   // The start time of the span. On the client side, this is the time kept by
   // the local machine where the span execution starts. On the server side, this


### PR DESCRIPTION
Proposal for adding a span kind that can be used also as an identity for the Span, this way we can remove the prefix "Sent." and "Recv." from the span names in grpc and http.