### PR TITLE
Metric: Wrap label values to distinguish between empty-string and unset.

### DIFF
--- a/opencensus/proto/stats/metrics/metrics.proto
+++ b/opencensus/proto/stats/metrics/metrics.proto
@@ -83,18 +83,24 @@ message MetricDescriptor {
 // A collection of data points that describes the time-varying values
 // of a metric.
 message TimeSeries {
-  // TODO: Wrap values to distinguish between empty-string and unset.
   // TODO: Add restrictions for characters that can be used for keys and values.
   // The set of label values that uniquely identify this timeseries. Apply to all
   // points. The order of label values must match that of label keys in the
   // metric descriptor.
-  repeated string label_values = 1;
+  repeated LabelValue label_values = 1;
 
   // The data points of this timeseries. Point type MUST match the MetricDescriptor.type, so for
   // a CUMULATIVE type only cumulative_points are present and for a GAUGE type only gauge_points
   // are present.
   repeated GaugePoint gauge_points = 2;
   repeated CumulativePoint cumulative_points = 3;
+}
+
+message LabelValue {
+  // The value for the label.
+  string value = 1;
+  // If false the value field is ignored and considered not set.
+  bool has_value = 2;
 }
 
 // An instantaneous measurement of a value.


### PR DESCRIPTION
We need a way to distinguish between empty-string and unset for label values. Since `label_values` is a repeated field, using the built-in `Wrapper.StringValue` doesn't help in this case. Instead we need to define our own `LabelValue` type that wraps the string value, as suggested by @bogdandrutu in https://github.com/census-instrumentation/opencensus-proto/pull/55#discussion_r189125133.