### PR TITLE
Move exemplars in the Bucket.

### DIFF
--- a/opencensus/proto/metrics/metrics.proto
+++ b/opencensus/proto/metrics/metrics.proto
@@ -207,6 +207,9 @@ message DistributionValue {
     // The number of values in each bucket of the histogram, as described in
     // bucket_bounds.
     int64 count = 1;
+
+    // If the distribution does not have a histogram, then omit this field.
+    Exemplar exemplars = 2;
   }
 
   // If the distribution does not have a histogram, then omit this field.
@@ -228,7 +231,4 @@ message DistributionValue {
     // Contextual information about the example value.
     map<string, string> attachments = 3;
   }
-
-  // If the distribution does not have a histogram, then omit this field.
-  repeated Exemplar exemplars = 6;
 }

--- a/opencensus/proto/metrics/metrics.proto
+++ b/opencensus/proto/metrics/metrics.proto
@@ -209,7 +209,7 @@ message DistributionValue {
     int64 count = 1;
 
     // If the distribution does not have a histogram, then omit this field.
-    Exemplar exemplars = 2;
+    Exemplar exemplar = 2;
   }
 
   // If the distribution does not have a histogram, then omit this field.


### PR DESCRIPTION
Reasons:

1. Validation of the ordering is required in the previous model so no extra validation required.
2. Small size improvement in the representation: If you have 2 exemplars then you need memory for the 2 exemplars object + extra memory for the repeated field (size, etc.). One null object (in the new representation) is 0 bytes on the wire.