### PR TITLE
Change from multiple types of timeseries to have one.

### DIFF
--- a/opencensus/proto/metrics/metrics.proto
+++ b/opencensus/proto/metrics/metrics.proto
@@ -119,9 +119,10 @@ message LabelValue {
 
 // A timestamped measurement.
 message Point {
-  // Available only for cumulative metrics. The time when the cumulative value
+  // Must be present for cumulative metrics. The time when the cumulative value
   // was reset to zero. The cumulative value is over the time interval
-  // [start_timestamp, timestamp].
+  // [start_timestamp, timestamp]. If not specified, the backend can use the
+  // previous recorded value.
   google.protobuf.Timestamp start_timestamp = 1;
 
   // The moment when this point was recorded. If not specified, the timestamp

--- a/opencensus/proto/metrics/metrics.proto
+++ b/opencensus/proto/metrics/metrics.proto
@@ -99,6 +99,12 @@ message LabelKey {
 // A collection of data points that describes the time-varying values
 // of a metric.
 message TimeSeries {
+  // Must be present for cumulative metrics. The time when the cumulative value
+  // was reset to zero. The cumulative value is over the time interval
+  // [start_timestamp, timestamp]. If not specified, the backend can use the
+  // previous recorded value.
+  google.protobuf.Timestamp start_timestamp = 1;
+
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
   // metric descriptor.
@@ -119,26 +125,20 @@ message LabelValue {
 
 // A timestamped measurement.
 message Point {
-  // Must be present for cumulative metrics. The time when the cumulative value
-  // was reset to zero. The cumulative value is over the time interval
-  // [start_timestamp, timestamp]. If not specified, the backend can use the
-  // previous recorded value.
-  google.protobuf.Timestamp start_timestamp = 1;
-
   // The moment when this point was recorded. If not specified, the timestamp
   // will be decided by the backend.
-  google.protobuf.Timestamp timestamp = 2;
+  google.protobuf.Timestamp timestamp = 1;
 
   // The actual point value.
   oneof value {
     // A 64-bit integer.
-    int64 int64_value = 3;
+    int64 int64_value = 2;
 
     // A 64-bit double-precision floating-point number.
-    double double_value = 4;
+    double double_value = 3;
 
     // A distribution value.
-    DistributionValue distribution_value = 5;
+    DistributionValue distribution_value = 4;
 
     // TODO: Add support for Summary type. This is an aggregation that produces
     // percentiles directly.

--- a/opencensus/proto/metrics/metrics.proto
+++ b/opencensus/proto/metrics/metrics.proto
@@ -38,10 +38,8 @@ message Metric {
   MetricDescriptor metric_descriptor = 1;
 
   // One or more timeseries for a single metric, where each timeseries has
-  // one or more points. The type of the timeseries must match
-  // metric_descriptor.type, so only one of the two should be populated.
-  repeated GaugeTimeSeries gauge_timeseries = 2;
-  repeated CumulativeTimeSeries cumulative_timeseries = 3;
+  // one or more points.
+  repeated TimeSeries timeseries = 2;
 }
 
 // Defines a metric type and its schema.
@@ -99,29 +97,15 @@ message LabelKey {
 }
 
 // A collection of data points that describes the time-varying values
-// of a gauge metric.
-message GaugeTimeSeries {
-  // The set of label values that uniquely identify this timeseries. Applies to
-  // all points. The order of label values must match that of label keys in the
-  // metric descriptor.
-  repeated LabelValue label_values = 1;
-
-  // The data points of this timeseries. Point type MUST match the MetricDescriptor.type.
-  repeated Point points = 2;
-}
-
-// A collection of data points that describes the time-varying values
-// of a cumulative metric.
-message CumulativeTimeSeries {
-  // The time that the cumulative value was reset to zero.
-  google.protobuf.Timestamp start_time = 1; // required
-
+// of a metric.
+message TimeSeries {
   // The set of label values that uniquely identify this timeseries. Applies to
   // all points. The order of label values must match that of label keys in the
   // metric descriptor.
   repeated LabelValue label_values = 2;
 
-  // The data points of this timeseries. Point type MUST match the MetricDescriptor.type.
+  // The data points of this timeseries. Point.value type MUST match the
+  // MetricDescriptor.type.
   repeated Point points = 3;
 }
 
@@ -135,19 +119,25 @@ message LabelValue {
 
 // A timestamped measurement.
 message Point {
-  // The moment when this point was recorded.
-  google.protobuf.Timestamp timestamp = 1; // required
+  // Available only for cumulative metrics. The time when the cumulative value
+  // was reset to zero. The cumulative value is over the time interval
+  // [start_timestamp, timestamp].
+  google.protobuf.Timestamp start_timestamp = 1;
+
+  // The moment when this point was recorded. If not specified, the timestamp
+  // will be decided by the backend.
+  google.protobuf.Timestamp timestamp = 2;
 
   // The actual point value.
   oneof value {
     // A 64-bit integer.
-    int64 int64_value = 2;
+    int64 int64_value = 3;
 
     // A 64-bit double-precision floating-point number.
-    double double_value = 3;
+    double double_value = 4;
 
     // A distribution value.
-    DistributionValue distribution_value = 4;
+    DistributionValue distribution_value = 5;
 
     // TODO: Add support for Summary type. This is an aggregation that produces
     // percentiles directly.


### PR DESCRIPTION
Pros:

1. Easier to add new types (not gauge, or cumulative). This may not be immediately useful but in the future may make a difference.
2. Simplify the code by removing one extra type.
3. Compatible with SD and OpenMetrics effort.

Cons:

1. Checking that data are valid is harder in the new proposal. But OpenCensus tries to do minimal validation of the data (relying more on the apis/implementations that produce the data to do the right thing).