### PR TITLE
Add agent trace service proto definitions.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,6 +14,21 @@
 
 workspace(name = "opencensus_proto")
 
+# Import gRPC git repo so that we can load java_grpc_library build.
+git_repository(
+    name = "grpc_java",
+    remote = "https://github.com/grpc/grpc-java.git",
+    tag = "v1.10.1",
+)
+
+load("@grpc_java//:repositories.bzl", "grpc_java_repositories")
+
+grpc_java_repositories(
+    # Omit to avoid conflicts.
+    omit_com_google_protobuf=True,
+    omit_com_google_protobuf_nano_protobuf_javanano=True,
+)
+
 # proto_library rules implicitly depend on @com_google_protobuf//:protoc,
 # which is the proto-compiler.
 # This statement defines the @com_google_protobuf repo.

--- a/opencensus/proto/agent/common/v1/BUILD.bazel
+++ b/opencensus/proto/agent/common/v1/BUILD.bazel
@@ -14,10 +14,39 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
 proto_library(
     name = "common_proto",
     srcs = ["common.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
     ],
+)
+
+proto_library(
+    name = "trace_service_proto",
+    srcs = ["trace/v1/trace_service.proto"],
+    deps = [
+        ":common_proto",
+        "//opencensus/proto/trace:trace_proto",
+    ],
+)
+
+# TODO(songya): add metrics and stats services.
+
+cc_proto_library(
+    name = "trace_service_proto_cc",
+    deps = [":trace_service_proto"],
+)
+
+java_proto_library(
+    name = "trace_service_proto_java",
+    deps = [":trace_service_proto"],
+)
+
+java_grpc_library(
+    name = "trace_service_grpc_java",
+    srcs = [":trace_service_proto"],
+    deps = [":trace_service_proto_java"],
 )

--- a/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -41,3 +41,14 @@ java_grpc_library(
     srcs = [":trace_service_proto"],
     deps = [":trace_service_proto_java"],
 )
+
+# TODO(songya): resolve dependencies and add go_proto_library if it's needed.
+#go_proto_library(
+#    name = "trace_service_proto_go",
+#    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+#    importpath =
+#    "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1",
+#    proto = ":trace_service_proto",
+#    deps = [
+#    ],
+#)

--- a/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -14,10 +14,30 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
 proto_library(
-    name = "common_proto",
-    srcs = ["common.proto"],
+    name = "trace_service_proto",
+    srcs = ["trace_service.proto"],
     deps = [
-        "@com_google_protobuf//:timestamp_proto",
+        "//opencensus/proto/agent/common/v1:common_proto",
+        "//opencensus/proto/trace/v1:trace_proto",
+        "//opencensus/proto/trace/v1:trace_config_proto",
     ],
+)
+
+cc_proto_library(
+    name = "trace_service_proto_cc",
+    deps = [":trace_service_proto"],
+)
+
+java_proto_library(
+    name = "trace_service_proto_java",
+    deps = [":trace_service_proto"],
+)
+
+java_grpc_library(
+    name = "trace_service_grpc_java",
+    srcs = [":trace_service_proto"],
+    deps = [":trace_service_proto_java"],
 )

--- a/opencensus/proto/agent/trace/v1/trace_service.proto
+++ b/opencensus/proto/agent/trace/v1/trace_service.proto
@@ -20,14 +20,14 @@ syntax = "proto3";
 package opencensus.proto.agent.trace.v1;
 
 import "opencensus/proto/agent/common/v1/common.proto";
-import "opencensus/proto/trace/trace.proto";
-import "opencensus/proto/trace/trace_config.proto";
+import "opencensus/proto/trace/v1/trace.proto";
+import "opencensus/proto/trace/v1/trace_config.proto";
 
 option java_multiple_files = true;
 option java_package = "io.opencensus.proto.agent.trace.v1";
 option java_outer_classname = "TraceServiceProto";
 
-option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agentproto/traceserviceproto/v1";
+option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1";
 
 service TraceService {
 
@@ -48,12 +48,12 @@ message ConfigTraceServiceRequest {
   opencensus.proto.agent.common.v1.Node node = 1;
 
   // Current configuration.
-  opencensus.proto.trace.TraceConfig config = 2;
+  opencensus.proto.trace.v1.TraceConfig config = 2;
 }
 
 message ConfigTraceServiceResponse {
   // Requested updated configuration.
-  opencensus.proto.trace.TraceConfig config = 2;
+  opencensus.proto.trace.v1.TraceConfig config = 2;
 }
 
 message ExportTraceServiceRequest {
@@ -61,7 +61,7 @@ message ExportTraceServiceRequest {
   // This is required only in the first message on the stream.
   opencensus.proto.agent.common.v1.Node node = 1;
 
-  repeated opencensus.proto.trace.Span spans = 2;
+  repeated opencensus.proto.trace.v1.Span spans = 2;
 }
 
 message ExportTraceServiceResponse {

--- a/opencensus/proto/agent/trace/v1/trace_service.proto
+++ b/opencensus/proto/agent/trace/v1/trace_service.proto
@@ -1,0 +1,68 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// NOTE: This proto is experimental and is subject to change at this point.
+// Please do not use it at the moment.
+
+package opencensus.proto.agent.trace.v1;
+
+import "opencensus/proto/agent/common/v1/common.proto";
+import "opencensus/proto/trace/trace.proto";
+import "opencensus/proto/trace/trace_config.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opencensus.proto.agent.trace.v1";
+option java_outer_classname = "TraceServiceProto";
+
+option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agentproto/traceserviceproto/v1";
+
+service TraceService {
+
+  // After the initialization this RPC must be kept alive for the
+  // entire life of the application. Agent pushes configs to the
+  // application via a stream of responses.
+  rpc Config(stream ConfigTraceServiceRequest) returns (stream ConfigTraceServiceResponse) {}
+
+  // Allow to export Spans.
+  // For performance reason, it is recommended to keep this RPC
+  // alive for the entire life of the application.
+  rpc Export(stream ExportTraceServiceRequest) returns (stream ExportTraceServiceResponse) {}
+}
+
+message ConfigTraceServiceRequest {
+  // Identifier data effectively is a structured metadata.
+  // This is required only in the first message on the stream.
+  opencensus.proto.agent.common.v1.Node node = 1;
+
+  // Current configuration.
+  opencensus.proto.trace.TraceConfig config = 2;
+}
+
+message ConfigTraceServiceResponse {
+  // Requested updated configuration.
+  opencensus.proto.trace.TraceConfig config = 2;
+}
+
+message ExportTraceServiceRequest {
+  // Identifier data effectively is a structured metadata.
+  // This is required only in the first message on the stream.
+  opencensus.proto.agent.common.v1.Node node = 1;
+
+  repeated opencensus.proto.trace.Span spans = 2;
+}
+
+message ExportTraceServiceResponse {
+}


### PR DESCRIPTION
Also add `java_grpc_library` build rule so that the generated gRPC service can work with Java-Bazel build.

I feel it's better to put the proto definitions under opencensus-proto, and use the gen-go files in the agent/service repo.

Next step: update the gen-go files.

/cc @rakyll @SergeyKanzhelev @lmolkova @draffensperger 