### PR TITLE
Make tracestate a list instead of a map to preserve ordering.

### DIFF
--- a/opencensus/proto/trace/v1/trace.proto
+++ b/opencensus/proto/trace/v1/trace.proto
@@ -47,25 +47,31 @@ message Span {
   // This field is required.
   bytes span_id = 2;
 
-  message TraceStateEntry {
-    // The key must begin with a lowercase letter, and can only contain
-    // lowercase letters 'a'-'z', digits '0'-'9', underscores '_', dashes '-',
-    // asterisks '*', and forward slashes '/'. For multi-tenant vendors
-    // scenarios '@' sign can be used to prefix vendor name. The maximum length
-    // for the key is 256 characters.
-    string key = 1;
-
-    // The value is opaque string up to 256 characters printable ASCII RFC0020
-    // characters (i.e., the range 0x20 to 0x7E) except ',' and '='. Note that
-    // this also excludes tabs, newlines, carriage returns, etc.
-    string value = 2;
-  }
-
   // This field conveys information about request position in multiple distributed tracing graphs.
-  // It is a list of TraceStateEntry with a maximum of 32 members in the list.
+  // It is a list of Tracestate.Entry with a maximum of 32 members in the list.
   //
   // See the https://github.com/w3c/distributed-tracing for more details about this field.
-  repeated TraceStateEntry trace_state_entries = 15;
+  message Tracestate {
+    message Entry {
+      // The key must begin with a lowercase letter, and can only contain
+      // lowercase letters 'a'-'z', digits '0'-'9', underscores '_', dashes
+      // '-', asterisks '*', and forward slashes '/'. For multi-tenant vendors
+      // scenarios '@' sign can be used to prefix vendor name. The maximum
+      // length for the key is 256 characters.
+      string key = 1;
+
+      // The value is opaque string up to 256 characters printable ASCII
+      // RFC0020 characters (i.e., the range 0x20 to 0x7E) except ',' and '='.
+      // Note that this also excludes tabs, newlines, carriage returns, etc.
+      string value = 2;
+    }
+
+    // A list of entries that represent the Tracestate.
+    repeated Entry entries = 1;
+  }
+
+  // The Tracestate on the span.
+  Tracestate tracestate = 15;
 
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.

--- a/opencensus/proto/trace/v1/trace.proto
+++ b/opencensus/proto/trace/v1/trace.proto
@@ -47,22 +47,25 @@ message Span {
   // This field is required.
   bytes span_id = 2;
 
-  // The `tracestate` field conveys information about request position in multiple distributed
-  // tracing graphs.
-  //
-  // There can be a maximum of 32 members in the map.
-  //
-  // The key must begin with a lowercase letter, and can only contain lowercase letters 'a'-'z',
-  // digits '0'-'9', underscores '_', dashes '-', asterisks '*', and forward slashes '/'. For
-  // multi-tenant vendors scenarios '@' sign can be used to prefix vendor name. The maximum length
-  // for the key is 256 characters.
-  //
-  // The value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the
-  // range 0x20 to 0x7E) except ',' and '='. Note that this also excludes tabs, newlines, carriage
-  // returns, etc.
+  message TraceStateEntry {
+    // The key must begin with a lowercase letter, and can only contain
+    // lowercase letters 'a'-'z', digits '0'-'9', underscores '_', dashes '-',
+    // asterisks '*', and forward slashes '/'. For multi-tenant vendors
+    // scenarios '@' sign can be used to prefix vendor name. The maximum length
+    // for the key is 256 characters.
+    string key = 1;
+
+    // The value is opaque string up to 256 characters printable ASCII RFC0020
+    // characters (i.e., the range 0x20 to 0x7E) except ',' and '='. Note that
+    // this also excludes tabs, newlines, carriage returns, etc.
+    string value = 2;
+  }
+
+  // This field conveys information about request position in multiple distributed tracing graphs.
+  // It is a list of TraceStateEntry with a maximum of 32 members in the list.
   //
   // See the https://github.com/w3c/distributed-tracing for more details about this field.
-  map<string, string> tracestate = 15;
+  repeated TraceStateEntry trace_state = 15;
 
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.

--- a/opencensus/proto/trace/v1/trace.proto
+++ b/opencensus/proto/trace/v1/trace.proto
@@ -65,7 +65,7 @@ message Span {
   // It is a list of TraceStateEntry with a maximum of 32 members in the list.
   //
   // See the https://github.com/w3c/distributed-tracing for more details about this field.
-  repeated TraceStateEntry trace_state = 15;
+  repeated TraceStateEntry trace_state_entries = 15;
 
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.

--- a/opencensus/proto/trace/v1/trace.proto
+++ b/opencensus/proto/trace/v1/trace.proto
@@ -55,9 +55,7 @@ message Span {
     message Entry {
       // The key must begin with a lowercase letter, and can only contain
       // lowercase letters 'a'-'z', digits '0'-'9', underscores '_', dashes
-      // '-', asterisks '*', and forward slashes '/'. For multi-tenant vendors
-      // scenarios '@' sign can be used to prefix vendor name. The maximum
-      // length for the key is 256 characters.
+      // '-', asterisks '*', and forward slashes '/'.
       string key = 1;
 
       // The value is opaque string up to 256 characters printable ASCII


### PR DESCRIPTION
One thing I want to confirm is the name tracestate vs trace_state. I don't like the fact that tracestate is not a real word so all the time the spelling checker triggers on this.