### PR TITLE
agent/trace/v1: fix signature for Export and comments too

### DIFF
--- a/opencensus/proto/agent/trace/v1/trace_service.proto
+++ b/opencensus/proto/agent/trace/v1/trace_service.proto
@@ -30,14 +30,13 @@ option java_outer_classname = "TraceServiceProto";
 option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1";
 
 service TraceService {
+  // After initialization, this RPC must be kept alive for the
+  // entire life of the application. The agent pushes configs
+  // down to applications via a stream of requests.
+  rpc Config(stream ConfigTraceServiceResponse) returns (stream ConfigTraceServiceRequest) {}
 
-  // After the initialization this RPC must be kept alive for the
-  // entire life of the application. Agent pushes configs to the
-  // application via a stream of responses.
-  rpc Config(stream ConfigTraceServiceRequest) returns (stream ConfigTraceServiceResponse) {}
-
-  // Allow to export Spans.
-  // For performance reason, it is recommended to keep this RPC
+  // Allows applications to send spans to the agent.
+  // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
   rpc Export(stream ExportTraceServiceRequest) returns (stream ExportTraceServiceResponse) {}
 }


### PR DESCRIPTION
agent/trace/v1: fix signature for Config and comments too
  
* Fix the signature for Config since the service sends
down to applications on  a stream of ConfigTraceServiceRequests
and receives responses on a stream of ConfigTraceServiceResponses

* Update TraceService comments

Fixes #89