### PR TITLE
agent/common/v1: use exporter_version, core_library_version in LibraryInfo

### DIFF
--- a/opencensus/proto/agent/common/v1/common.proto
+++ b/opencensus/proto/agent/common/v1/common.proto
@@ -83,7 +83,10 @@ message LibraryInfo {
   Language language = 1;
 
   // Version of Agent exporter of Library.
-  string version = 2;
+  string exporter_version = 2;
+
+  // Version of OpenCensus Library.
+  string core_library_version = 3;
 }
 
 // Additional service information.


### PR DESCRIPTION
By using:
* `exporter_version`(previously `version`, but same field id: 2)
* `core_library_version` -- version of OpenCensus Library

we can succinctly convey information to the agent about the
exporter and core libraries used.

Updates #99