### PR TITLE
Bump version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: "signing"
 
 group = "io.opencensus"
-version = "0.0.2" // CURRENT_OPENCENSUS_PROTO_VERSION
+version = "0.0.3-SNAPSHOT" // CURRENT_OPENCENSUS_PROTO_VERSION
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: "signing"
 
 group = "io.opencensus"
-version = "0.0.2-SNAPSHOT" // CURRENT_OPENCENSUS_PROTO_VERSION
+version = "0.0.2" // CURRENT_OPENCENSUS_PROTO_VERSION
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.opencensus</groupId>
   <artifactId>opencensus-proto</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.0.2</version>
 
   <name>OpenCensus Proto</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.opencensus</groupId>
   <artifactId>opencensus-proto</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3-SNAPSHOT</version>
 
   <name>OpenCensus Proto</name>
 


### PR DESCRIPTION
Bump version in order to keep the version of the upcoming Maven release consistent with Github tag. For v0.0.1, the Github tag is not consistent with gradle version.

Thanks @reyang for catching this.