### PR TITLE
Gradle: Add missing sourceJar and javadocJar rules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,25 @@ signing {
     sign configurations.archives
 }
 
+javadoc.options {
+    encoding = 'UTF-8'
+    links 'https://docs.oracle.com/javase/8/docs/api/'
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
 uploadArchives {
         repositories {
             mavenDeployer {


### PR DESCRIPTION
Otherwise OSS Sonatype will fail when trying to close the staging repo.