### PR TITLE
Extend the TraceService service to support export/config for multiple Applications.

### DIFF
--- a/src/opencensus/proto/agent/common/v1/common.proto
+++ b/src/opencensus/proto/agent/common/v1/common.proto
@@ -27,9 +27,10 @@ option java_outer_classname = "CommonProto";
 
 option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1";
 
-// Identifier metadata of the Node that connects to OpenCensus Agent.
+// Identifier metadata of the Node (Application instrumented with OpenCensus)
+// that connects to OpenCensus Agent.
 // In the future we plan to extend the identifier proto definition to support
-// additional information (e.g cloud id, monitored resource, etc.)
+// additional information (e.g cloud id, etc.)
 message Node {
   // Identifier that uniquely identifies a process within a VM/container.
   ProcessIdentifier identifier = 1;
@@ -37,7 +38,7 @@ message Node {
   // Information on the OpenCensus Library who initiates the stream.
   LibraryInfo library_info = 2;
 
-  // Additional informantion on service.
+  // Additional information on service.
   ServiceInfo service_info = 3;
 
   // Additional attributes.
@@ -59,8 +60,6 @@ message ProcessIdentifier {
 
   // Start time of this ProcessIdentifier. Represented in epoch time.
   google.protobuf.Timestamp start_timestamp = 3;
-
-  // TODO(songya): Add more fields in the future as needed.
 }
 
 // Information on OpenCensus Library.

--- a/src/opencensus/proto/agent/common/v1/common.proto
+++ b/src/opencensus/proto/agent/common/v1/common.proto
@@ -35,7 +35,7 @@ message Node {
   // Identifier that uniquely identifies a process within a VM/container.
   ProcessIdentifier identifier = 1;
 
-  // Information on the OpenCensus Library who initiates the stream.
+  // Information on the OpenCensus Library that initiates the stream.
   LibraryInfo library_info = 2;
 
   // Additional information on service.

--- a/src/opencensus/proto/agent/trace/v1/trace_service.proto
+++ b/src/opencensus/proto/agent/trace/v1/trace_service.proto
@@ -29,21 +29,25 @@ option java_outer_classname = "TraceServiceProto";
 
 option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1";
 
+// Service that can be used to push spans and configs between one Application
+// instrumented with OpenCensus and an agent, or between an agent and a
+// central collector or config service (in this case spans and configs are
+// sent/received to/from multiple Applications).
 service TraceService {
-  // After initialization, this RPC must be kept alive for the
-  // entire life of the application. The agent pushes configs
-  // down to applications via a stream.
+  // After initialization, this RPC must be kept alive for the entire life of
+  // the application. The agent pushes configs down to applications via a
+  // stream.
   rpc Config(stream CurrentLibraryConfig) returns (stream UpdatedLibraryConfig) {}
 
-  // Allows applications to send spans to the agent.
   // For performance reasons, it is recommended to keep this RPC
   // alive for the entire life of the application.
   rpc Export(stream ExportTraceServiceRequest) returns (stream ExportTraceServiceResponse) {}
 }
 
 message CurrentLibraryConfig {
-  // Identifier data effectively is a structured metadata.
-  // This is required only in the first message on the stream.
+  // This is required only in the first message on the stream or if the
+  // previous sent CurrentLibraryConfig message has a different Node (e.g.
+  // when the same RPC is used to configure multiple Applications).
   opencensus.proto.agent.common.v1.Node node = 1;
 
   // Current configuration.
@@ -51,15 +55,22 @@ message CurrentLibraryConfig {
 }
 
 message UpdatedLibraryConfig {
+  // This field is ignored when the RPC is used to configure only one Application.
+  // This is required only in the first message on the stream or if the
+  // previous sent UpdatedLibraryConfig message has a different Node.
+  opencensus.proto.agent.common.v1.Node node = 1;
+
   // Requested updated configuration.
   opencensus.proto.trace.v1.TraceConfig config = 2;
 }
 
 message ExportTraceServiceRequest {
-  // Identifier data effectively is a structured metadata.
-  // This is required only in the first message on the stream.
+  // This is required only in the first message on the stream or if the
+  // previous sent ExportTraceServiceRequest message has a different Node (e.g.
+  // when the same RPC is used to send Spans from multiple Applications).
   opencensus.proto.agent.common.v1.Node node = 1;
 
+  // A list of Spans that belong to the last received Node.
   repeated opencensus.proto.trace.v1.Span spans = 2;
 }
 


### PR DESCRIPTION
This generalization of the TraceService grpc service. This change is a no-op for previously written OC library exporters or server implementations.

Any ocagent exporters does not need to change because:
  * Node is sent only in the first message because these exporters only export data for one instrumented application (Node);
  * The Node message in the UpdateTraceConfig is ignored (even if it gets received it will be the same as the application sent initially).

Any previous server implementation of this protocol does not need to change because:
  * Supposed to work directly with Applications so only one Node per RPC received.
  * The Node message in the UpdateTraceConfig is ignored by the client (if the client is an Application), so the fact that is not sent does not affect the protocol.
