### PR TITLE
[Proposal] Agent: Add metrics service.

### DIFF
--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -1,0 +1,59 @@
+# Copyright 2018, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+
+proto_library(
+    name = "metrics_service_proto",
+    srcs = ["metrics_service.proto"],
+    deps = [
+        "//opencensus/proto/agent/common/v1:common_proto",
+        "//opencensus/proto/metrics/v1:metrics_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "metrics_service_proto_cc",
+    deps = [":metrics_service_proto"],
+)
+
+java_proto_library(
+    name = "metrics_service_proto_java",
+    deps = [":metrics_service_proto"],
+)
+
+java_grpc_library(
+    name = "metrics_service_grpc_java",
+    srcs = [":metrics_service_proto"],
+    deps = [":metrics_service_proto_java"],
+)
+
+go_proto_library(
+    name = "metrics_service_proto_go",
+    protos = ["metrics_service.proto"],
+    imports = [
+        "external/com_google_protobuf/src",
+    ],
+    proto_deps = [
+        "//opencensus/proto/agent/common/v1:common_proto_go",
+        "//opencensus/proto/metrics/v1:metrics_proto_go",
+    ],
+    pb_options = [
+       # omit the go_package declared in proto files to make bazel works as expect
+       "paths=source_relative",
+    ],
+)

--- a/src/opencensus/proto/agent/metrics/v1/metrics_service.proto
+++ b/src/opencensus/proto/agent/metrics/v1/metrics_service.proto
@@ -1,0 +1,48 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package opencensus.proto.agent.metrics.v1;
+
+import "opencensus/proto/agent/common/v1/common.proto";
+import "opencensus/proto/metrics/v1/metrics.proto";
+
+option java_multiple_files = true;
+option java_package = "io.opencensus.proto.agent.metrics.v1";
+option java_outer_classname = "MetricsServiceProto";
+
+option go_package = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1";
+
+// Service that can be used to push metrics between one Application
+// instrumented with OpenCensus and an agent, or between an agent and a
+// central collector.
+service MetricsService {
+  // For performance reasons, it is recommended to keep this RPC
+  // alive for the entire life of the application.
+  rpc Export(stream ExportMetricsServiceRequest) returns (stream ExportMetricsServiceResponse) {}
+}
+
+message ExportMetricsServiceRequest {
+  // This is required only in the first message on the stream or if the
+  // previous sent ExportMetricsServiceRequest message has a different Node (e.g.
+  // when the same RPC is used to send Metrics from multiple Applications).
+  opencensus.proto.agent.common.v1.Node node = 1;
+
+  // A list of metrics that belong to the last received Node.
+  repeated opencensus.proto.metrics.v1.Metric metrics = 2;
+}
+
+message ExportMetricsServiceResponse {
+}


### PR DESCRIPTION
`metrics.proto` hasn't been finalized yet but any future changes should be backwards-compatible and won't affect the metrics service. 

Currently there's only `Export` in the metrics service.