### PR TITLE
README: Add instructions on using opencensus_proto with Bazel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,27 @@ compile 'io.opencensus:opencensus-proto:0.0.2'
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-proto
 [maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-proto/badge.svg
 [maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-proto
+
+### Add the dependencies to Bazel project
+
+In WORKSPACE, add:
+```
+http_archive(
+    name = "io_opencensus_proto",
+    strip_prefix = "opencensus-proto-master/src",
+    urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/master.zip"],
+)
+```
+
+In BUILD.bazel:
+```bazel
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+    deps = [
+      "@io_opencensus_proto//opencensus/proto/metrics/v1:metrics_proto",
+      "@io_opencensus_proto//opencensus/proto/trace/v1:trace_proto",
+      # etc.
+    ],
+)
+```


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-proto/issues/105.