### PR TITLE
Add git_repository import to fix deprecation warning

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -15,6 +15,7 @@
 workspace(name = "opencensus_proto")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Import gRPC git repo so that we can load java_grpc_library build.
 git_repository(

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -14,6 +14,8 @@
 
 workspace(name = "opencensus_proto")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 # Import gRPC git repo so that we can load java_grpc_library build.
 git_repository(
     name = "grpc_java",

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -62,14 +62,14 @@ http_archive(
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    # we need rules_go of tag 0.12.0
+    # we need rules_go of tag 0.12.1
     # which includes golang protobuf that supports "paths=source_relative"
     # the "paths=source_relative" option for protoc-gen-go makes bazel works as expect
     # when go_package was declared in proto files
     # see https://github.com/bazelbuild/rules_go/blob/release-0.12/go/private/repositories.bzl#L75
     # for the included golang protobuf version and
     # see https://github.com/golang/protobuf/pull/544 for "paths=source_relative" usage
-    tag = "0.12.0",
+    tag = "0.12.1",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")


### PR DESCRIPTION
This is an attempt to fix the failing build for https://github.com/census-instrumentation/opencensus-proto/pull/77