### PR TITLE
Fix bazel build after bazel upgrade

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -13,6 +13,3 @@
 # limitations under the License.
 
 package(default_visibility = ["//visibility:public"])
-
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
-go_prefix("github.com/census-instrumentation/opencensus-proto")

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -62,32 +62,9 @@ http_archive(
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    # we need rules_go of tag 0.12.1
-    # which includes golang protobuf that supports "paths=source_relative"
-    # the "paths=source_relative" option for protoc-gen-go makes bazel works as expect
-    # when go_package was declared in proto files
-    # see https://github.com/bazelbuild/rules_go/blob/release-0.12/go/private/repositories.bzl#L75
-    # for the included golang protobuf version and
-    # see https://github.com/golang/protobuf/pull/544 for "paths=source_relative" usage
-    tag = "0.12.1",
+    tag = "0.15.8",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
-
-# golang protobuf rules related
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    commit = "5cae42382b620aa1e347ecf30b3e92fd0d97998c", # Jun 23, 2018
-    remote = "https://github.com/pubref/rules_protobuf.git",
-)
-
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_repositories")
-go_proto_repositories(
-  excludes = [
-        # we have specified protobuf above
-        # so ignore it in case version collision
-        "com_google_protobuf",
-  ],
-)

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -15,6 +15,7 @@
 workspace(name = "opencensus_proto")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Import gRPC git repo so that we can load java_grpc_library build.
 git_repository(

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -62,6 +62,13 @@ http_archive(
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
+    # we need rules_go of tag 0.12.0 or greater
+    # which includes golang protobuf that supports "paths=source_relative"
+    # the "paths=source_relative" option for protoc-gen-go makes bazel works as expect
+    # when go_package was declared in proto files
+    # see https://github.com/bazelbuild/rules_go/blob/release-0.12/go/private/repositories.bzl#L75
+    # for the included golang protobuf version and
+    # see https://github.com/golang/protobuf/pull/544 for "paths=source_relative" usage
     tag = "0.15.8",
 )
 

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -14,6 +14,8 @@
 
 workspace(name = "opencensus_proto")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 # Import gRPC git repo so that we can load java_grpc_library build.
 git_repository(
     name = "grpc_java",

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -62,14 +62,14 @@ http_archive(
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    # we need rules_go of tag 0.12.0
+    # we need rules_go of tag 0.12.1
     # which includes golang protobuf that supports "paths=source_relative"
     # the "paths=source_relative" option for protoc-gen-go makes bazel works as expect
     # when go_package was declared in proto files
     # see https://github.com/bazelbuild/rules_go/blob/release-0.12/go/private/repositories.bzl#L75
     # for the included golang protobuf version and
     # see https://github.com/golang/protobuf/pull/544 for "paths=source_relative" usage
-    tag = "0.12.0",
+    tag = "0.12.1",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/src/opencensus/proto/agent/common/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/common/v1/BUILD.bazel
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "common_proto",
@@ -26,17 +26,8 @@ proto_library(
 
 go_proto_library(
     name = "common_proto_go",
-    protos = ["common.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    inputs = [
-        "@com_google_protobuf//:well_known_protos",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
+    proto = ":common_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1",
     deps = [
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
     ],

--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -15,7 +15,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "metrics_service_proto",
@@ -45,17 +45,11 @@ java_grpc_library(
 
 go_proto_library(
     name = "metrics_service_proto_go",
-    protos = ["metrics_service.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    proto_deps = [
+    proto = ":metrics_service_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1",
+    deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/metrics/v1:metrics_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
     ],
 )

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -15,7 +15,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_service_proto",
@@ -46,18 +46,12 @@ java_grpc_library(
 
 go_proto_library(
     name = "trace_service_proto_go",
-    protos = ["trace_service.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    proto_deps = [
+    proto = ":trace_service_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1",
+    deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",
         "//opencensus/proto/trace/v1:trace_proto_go",
         "//opencensus/proto/trace/v1:trace_config_proto_go",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
     ],
 )

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -48,14 +48,9 @@ go_proto_library(
     name = "trace_service_proto_go",
     proto = ":trace_service_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1",
-    embed = [
-        "//opencensus/proto/trace/v1:trace_proto_go",
-        "//opencensus/proto/trace/v1:trace_config_proto_go",
-    ],
     deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",
-        "//opencensus/proto/trace/v1:trace_proto_go",
-        "//opencensus/proto/trace/v1:trace_config_proto_go",
+        "//opencensus/proto/trace/v1:trace_and_config_proto_go",
     ],
 )

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -24,7 +24,6 @@ proto_library(
         "//opencensus/proto/agent/common/v1:common_proto",
         "//opencensus/proto/resource/v1:resource_proto",
         "//opencensus/proto/trace/v1:trace_proto",
-        "//opencensus/proto/trace/v1:trace_config_proto",
     ],
 )
 
@@ -52,6 +51,5 @@ go_proto_library(
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",
         "//opencensus/proto/trace/v1:trace_proto_go",
-        "//opencensus/proto/trace/v1:trace_config_proto_go",
     ],
 )

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -24,6 +24,7 @@ proto_library(
         "//opencensus/proto/agent/common/v1:common_proto",
         "//opencensus/proto/resource/v1:resource_proto",
         "//opencensus/proto/trace/v1:trace_proto",
+        "//opencensus/proto/trace/v1:trace_config_proto",
     ],
 )
 
@@ -51,5 +52,6 @@ go_proto_library(
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",
         "//opencensus/proto/trace/v1:trace_proto_go",
+        "//opencensus/proto/trace/v1:trace_config_proto_go",
     ],
 )

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -48,6 +48,10 @@ go_proto_library(
     name = "trace_service_proto_go",
     proto = ":trace_service_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1",
+    embed = [
+        "//opencensus/proto/trace/v1:trace_proto_go",
+        "//opencensus/proto/trace/v1:trace_config_proto_go",
+    ],
     deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",

--- a/src/opencensus/proto/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/metrics/v1/BUILD.bazel
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "metrics_proto",
@@ -38,21 +38,10 @@ java_proto_library(
 
 go_proto_library(
     name = "metrics_proto_go",
-    protos = ["metrics.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    inputs = [
-        "@com_google_protobuf//:well_known_protos",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
-    proto_deps = [
-        "//opencensus/proto/resource/v1:resource_proto_go",
-    ],
+    proto = ":metrics_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1",
     deps = [
+        "//opencensus/proto/resource/v1:resource_proto_go",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],

--- a/src/opencensus/proto/resource/v1/BUILD.bazel
+++ b/src/opencensus/proto/resource/v1/BUILD.bazel
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "resource_proto",
@@ -33,9 +33,6 @@ java_proto_library(
 
 go_proto_library(
     name = "resource_proto_go",
-    protos = ["resource.proto"],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
+    proto = ":resource_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1",
 )

--- a/src/opencensus/proto/stats/v1/BUILD.bazel
+++ b/src/opencensus/proto/stats/v1/BUILD.bazel
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "stats_proto",
@@ -37,17 +37,8 @@ java_proto_library(
 
 go_proto_library(
     name = "stats_proto_go",
-    protos = ["stats.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    inputs = [
-        "@com_google_protobuf//:well_known_protos",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
+    proto = ":stats_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/stats/v1",
     deps = [
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
     ],

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -18,16 +18,14 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_proto",
-    srcs = ["trace.proto"],
+    srcs = [
+        "trace.proto",
+        "trace_config.proto"
+    ],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
     ],
-)
-
-proto_library(
-    name = "trace_config_proto",
-    srcs = ["trace_config.proto"],
 )
 
 cc_proto_library(
@@ -35,19 +33,9 @@ cc_proto_library(
     deps = [":trace_proto"],
 )
 
-cc_proto_library(
-    name = "trace_config_proto_cc",
-    deps = [":trace_config_proto"],
-)
-
 java_proto_library(
     name = "trace_proto_java",
     deps = [":trace_proto"],
-)
-
-java_proto_library(
-    name = "trace_config_proto_java",
-    deps = [":trace_config_proto"],
 )
 
 go_proto_library(
@@ -58,10 +46,4 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
-)
-
-go_proto_library(
-    name = "trace_config_proto_go",
-    proto = ":trace_config_proto",
-    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
 )

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -15,6 +15,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 proto_library(
     name = "trace_proto",
@@ -64,4 +65,17 @@ go_proto_library(
     name = "trace_config_proto_go",
     proto = ":trace_config_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
+)
+
+# This a workaround because `trace_proto_go` and `trace_config_proto_go` have
+# the same importpath, and so cause a compile issue if both are depended on
+# directly by another `go_proto_library` (such as `trace_service_proto_go`).
+# See: https://github.com/bazelbuild/rules_go/issues/1841
+go_library(
+    name = "trace_and_config_proto_go",
+    srcs = [],
+    embed = [
+        ":trace_proto_go",
+        ":trace_config_proto_go",
+    ]
 )

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -14,7 +14,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_protobuf//go:rules.bzl", "go_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_proto",
@@ -52,17 +52,8 @@ java_proto_library(
 
 go_proto_library(
     name = "trace_proto_go",
-    protos = ["trace.proto"],
-    imports = [
-        "external/com_google_protobuf/src",
-    ],
-    inputs = [
-        "@com_google_protobuf//:well_known_protos",
-    ],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
+    proto = ":trace_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
     deps = [
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
@@ -71,9 +62,6 @@ go_proto_library(
 
 go_proto_library(
     name = "trace_config_proto_go",
-    protos = ["trace_config.proto"],
-    pb_options = [
-       # omit the go_package declared in proto files to make bazel works as expect
-       "paths=source_relative",
-    ],
+    proto = ":trace_config_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
 )

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -18,16 +18,14 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_proto",
-    srcs = ["trace.proto"],
+    srcs = [
+      "trace.proto",
+      "trace_config.proto"
+    ],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
     ],
-)
-
-proto_library(
-    name = "trace_config_proto",
-    srcs = ["trace_config.proto"],
 )
 
 cc_proto_library(
@@ -35,19 +33,9 @@ cc_proto_library(
     deps = [":trace_proto"],
 )
 
-cc_proto_library(
-    name = "trace_config_proto_cc",
-    deps = [":trace_config_proto"],
-)
-
 java_proto_library(
     name = "trace_proto_java",
     deps = [":trace_proto"],
-)
-
-java_proto_library(
-    name = "trace_config_proto_java",
-    deps = [":trace_config_proto"],
 )
 
 go_proto_library(
@@ -58,10 +46,4 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
-)
-
-go_proto_library(
-    name = "trace_config_proto_go",
-    proto = ":trace_config_proto",
-    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
 )

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -18,14 +18,16 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_proto",
-    srcs = [
-        "trace.proto",
-        "trace_config.proto"
-    ],
+    srcs = ["trace.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
     ],
+)
+
+proto_library(
+    name = "trace_config_proto",
+    srcs = ["trace_config.proto"],
 )
 
 cc_proto_library(
@@ -33,9 +35,19 @@ cc_proto_library(
     deps = [":trace_proto"],
 )
 
+cc_proto_library(
+    name = "trace_config_proto_cc",
+    deps = [":trace_config_proto"],
+)
+
 java_proto_library(
     name = "trace_proto_java",
     deps = [":trace_proto"],
+)
+
+java_proto_library(
+    name = "trace_config_proto_java",
+    deps = [":trace_config_proto"],
 )
 
 go_proto_library(
@@ -46,4 +58,10 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
+)
+
+go_proto_library(
+    name = "trace_config_proto_go",
+    proto = ":trace_config_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
 )

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -18,14 +18,16 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "trace_proto",
-    srcs = [
-      "trace.proto",
-      "trace_config.proto"
-    ],
+    srcs = ["trace.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
     ],
+)
+
+proto_library(
+    name = "trace_config_proto",
+    srcs = ["trace_config.proto"],
 )
 
 cc_proto_library(
@@ -33,9 +35,19 @@ cc_proto_library(
     deps = [":trace_proto"],
 )
 
+cc_proto_library(
+    name = "trace_config_proto_cc",
+    deps = [":trace_config_proto"],
+)
+
 java_proto_library(
     name = "trace_proto_java",
     deps = [":trace_proto"],
+)
+
+java_proto_library(
+    name = "trace_config_proto_java",
+    deps = [":trace_config_proto"],
 )
 
 go_proto_library(
@@ -46,4 +58,10 @@ go_proto_library(
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
+)
+
+go_proto_library(
+    name = "trace_config_proto_go",
+    proto = ":trace_config_proto",
+    importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
 )


### PR DESCRIPTION
The bazel build was failing due to a variety of deprecation issues. 

This imports `git_repository` and `http_archive` from `@bazel_tools//tools/build_defs/repo:http.bzl`. This also required an upgrade to `@io_bazel_rules_go`, which then breaks `@org_pubref_rules_protobuf//go:rules.bzl`. 

To fix that, this switches to using `go_proto_library` from `@io_bazel_rules_go//proto:def.bzl`, which required some changes to the build params. This also combines the trace and trace config protos into a unified `trace_proto` build, which fixed a compile error for `//opencensus/proto/agent/trace/v1:trace_service_proto_go`.