### PR TITLE
Add command to generate OpenApi/Swagger doc for grpc-gateway

### DIFF
--- a/src/mkgogen.sh
+++ b/src/mkgogen.sh
@@ -23,3 +23,9 @@ protoc --go_out=plugins=grpc:$OUTDIR opencensus/proto/stats/v1/stats.proto \
     && protoc -I=. --go_out=plugins=grpc:$OUTDIR opencensus/proto/agent/metrics/v1/metrics_service.proto \
     && protoc -I=. --go_out=plugins=grpc:$OUTDIR opencensus/proto/agent/trace/v1/trace_service.proto \
     && protoc --grpc-gateway_out=logtostderr=true,grpc_api_configuration=./opencensus/proto/agent/trace/v1/trace_service_http.yaml:$OUTDIR opencensus/proto/agent/trace/v1/trace_service.proto
+
+# Generate OpenApi (Swagger) documentation file for grpc-gateway endpoints.
+OPENAPI_OUTDIR=../gen-openapi
+mkdir -p $OPENAPI_OUTDIR
+protoc --swagger_out=logtostderr=true,grpc_api_configuration=./opencensus/proto/agent/trace/v1/trace_service_http.yaml:$OPENAPI_OUTDIR \
+  opencensus/proto/agent/trace/v1/trace_service.proto


### PR DESCRIPTION
The [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) tool supports auto generating OpenAPI (formerly called Swagger) documentation files. This will be useful for users of the grpc-gateway to see what the HTTP/JSON format should look like.

This puts the command in `mkgogen.sh` to generate that documentation JSON file when the Go files are updated so that it stays up to date with the protos.