### PR TITLE
Fix Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - case "$BUILD" in
       "BAZEL")
         cd src;
-        bazel build --show_result=100 ... ;;
+        bazel build --incompatible_package_name_is_a_function=false --show_result=100 ... ;;
       "GRADLE")
         ./gradlew clean assemble --stacktrace ;
         ./gradlew check --stacktrace ;;


### PR DESCRIPTION
https://travis-ci.org/census-instrumentation/opencensus-proto/jobs/476958955#L581:
```bash
The value 'REPOSITORY_NAME' has been removed in favor of 'repository_name()', please use the latter (https://docs.bazel.build/versions/master/skylark/lib/native.html#repository_name). You can temporarily allow the old name by using --incompatible_package_name_is_a_function=false
```

This is caused by a transitive dependency (com_google_protobuf) so we have to set the flag for now.