### PR TITLE
Upgrade protobuf dependency to v3.6.1.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - case "$BUILD" in
       "BAZEL")
         cd src;
-        bazel build --incompatible_package_name_is_a_function=false --show_result=100 ... ;;
+        bazel build --show_result=100 ... ;;
       "GRADLE")
         ./gradlew clean assemble --stacktrace ;
         ./gradlew check --stacktrace ;;

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -37,25 +37,25 @@ grpc_java_repositories(
 # This statement defines the @com_google_protobuf repo.
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f",
-    strip_prefix = "protobuf-3.5.1",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.1.tar.gz"],
+    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.tar.gz"],
 )
 
 http_archive(
     name = "com_google_protobuf_cc",
-    sha256 = "826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f",
-    strip_prefix = "protobuf-3.5.1",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.1.tar.gz"],
+    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.tar.gz"],
 )
 
 # java_proto_library rules implicitly depend on @com_google_protobuf_java//:java_toolchain,
 # which is the Java proto runtime (base classes and common utilities).
 http_archive(
     name = "com_google_protobuf_java",
-    sha256 = "826425182ee43990731217b917c5c3ea7190cfda141af4869e6d4ad9085a740f",
-    strip_prefix = "protobuf-3.5.1",
-    urls = ["https://github.com/google/protobuf/archive/v3.5.1.tar.gz"],
+    sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+    strip_prefix = "protobuf-3.6.1.3",
+    urls = ["https://github.com/google/protobuf/archive/v3.6.1.3.tar.gz"],
 )
 
 # go rules related


### PR DESCRIPTION
This fixes the build (REPOSITORY_NAME error) with bazel 0.21.
(and reverts the workaround from #165)

grpc did the same thing: https://github.com/grpc/grpc/issues/17564