### PR TITLE
Revert "Start 0.3.0 development cycle"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'maven'
 apply plugin: "signing"
 
 group = "io.opencensus"
-version = "0.3.0-SNAPSHOT" // CURRENT_OPENCENSUS_PROTO_VERSION
+version = "0.2.0-SNAPSHOT" // CURRENT_OPENCENSUS_PROTO_VERSION
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
Reverts census-instrumentation/opencensus-proto#167.

We haven't made the v0.2.0 release yet. Revert this change to start over the release process.