### PR TITLE
Add Web JS as a LibraryInfo.Language option

### DIFF
--- a/src/opencensus/proto/agent/common/v1/common.proto
+++ b/src/opencensus/proto/agent/common/v1/common.proto
@@ -78,6 +78,7 @@ message LibraryInfo {
     PHP = 7;
     PYTHON = 8;
     RUBY = 9;
+    WEB_JS = 10;
   }
 
   // Language of OpenCensus Library.


### PR DESCRIPTION
This would be for spans generated by the [opencensus-web](https://github.com/census-instrumentation/opencensus-web) library.