### PR TITLE
Remove grpc_java_repositories from Bazel build.

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -17,21 +17,6 @@ workspace(name = "opencensus_proto")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Import gRPC git repo so that we can load java_grpc_library build.
-git_repository(
-    name = "grpc_java",
-    remote = "https://github.com/grpc/grpc-java.git",
-    tag = "v1.10.1",
-)
-
-load("@grpc_java//:repositories.bzl", "grpc_java_repositories")
-
-grpc_java_repositories(
-    # Omit to avoid conflicts.
-    omit_com_google_protobuf=True,
-    omit_com_google_protobuf_nano_protobuf_javanano=True,
-)
-
 # proto_library rules implicitly depend on @com_google_protobuf//:protoc,
 # which is the proto-compiler.
 # This statement defines the @com_google_protobuf repo.

--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -14,7 +14,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -35,12 +34,6 @@ cc_proto_library(
 java_proto_library(
     name = "metrics_service_proto_java",
     deps = [":metrics_service_proto"],
-)
-
-java_grpc_library(
-    name = "metrics_service_grpc_java",
-    srcs = [":metrics_service_proto"],
-    deps = [":metrics_service_proto_java"],
 )
 
 go_proto_library(

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -14,7 +14,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
@@ -36,12 +35,6 @@ cc_proto_library(
 java_proto_library(
     name = "trace_service_proto_java",
     deps = [":trace_service_proto"],
-)
-
-java_grpc_library(
-    name = "trace_service_grpc_java",
-    srcs = [":trace_service_proto"],
-    deps = [":trace_service_proto_java"],
 )
 
 go_proto_library(


### PR DESCRIPTION
For Java we use Gradle to generate and upload the jar, and other libraries should depend on https://search.maven.org/artifact/io.opencensus/opencensus-proto/. Bazel build rules is not very useful. In addition `grpc_java_repositories` has caused build failures in Travis (e.g https://travis-ci.org/census-instrumentation/opencensus-proto/jobs/557790386). 