### PR TITLE
Bring back bazel cache to make CI faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ install:
         wget "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh" ;
         chmod +x bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh ;
         ./bazel-${BAZEL_VERSION}-installer-${BAZEL_OS}-x86_64.sh --user ;
+        echo "build --disk_cache=$HOME/bazel-cache" > ~/.bazelrc ;
+        echo "build --experimental_strict_action_env" >> ~/.bazelrc ;
         bazel version ;;
     esac
 


### PR DESCRIPTION
This was added in #176 then reverted in #207.