### PR TITLE
Remove grpc_java dependency and java_proto rules.

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -17,17 +17,6 @@ workspace(name = "opencensus_proto")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# Import grpc_java for java_grpc_library().
-git_repository(
-    name = "grpc_java",
-    remote = "https://github.com/grpc/grpc-java.git",
-    tag = "v1.22.1",
-)
-
-load("@grpc_java//:repositories.bzl", "grpc_java_repositories")
-
-grpc_java_repositories()
-
 # Import grpc for cc_grpc_library().
 http_archive(
     name = "com_github_grpc_grpc",

--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -14,7 +14,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
@@ -38,17 +37,6 @@ cc_grpc_library(
     srcs = [":metrics_service_proto"],
     deps = [":metrics_service_proto_cc"],
     grpc_only = True,
-)
-
-java_proto_library(
-    name = "metrics_service_proto_java",
-    deps = [":metrics_service_proto"],
-)
-
-java_grpc_library(
-    name = "metrics_service_grpc_java",
-    srcs = [":metrics_service_proto"],
-    deps = [":metrics_service_proto_java"],
 )
 
 go_proto_library(

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -14,7 +14,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 
@@ -39,17 +38,6 @@ cc_grpc_library(
     srcs = [":trace_service_proto"],
     deps = [":trace_service_proto_cc"],
     grpc_only = True,
-)
-
-java_proto_library(
-    name = "trace_service_proto_java",
-    deps = [":trace_service_proto"],
-)
-
-java_grpc_library(
-    name = "trace_service_grpc_java",
-    srcs = [":trace_service_proto"],
-    deps = [":trace_service_proto_java"],
 )
 
 go_proto_library(


### PR DESCRIPTION
This is so that Envoy can consume opencensus-proto without adding
a dependency on grpc_java.