### PR TITLE
Load proto_library() rule.

### DIFF
--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -54,7 +54,7 @@ git_repository(
     # see https://github.com/bazelbuild/rules_go/blob/release-0.12/go/private/repositories.bzl#L75
     # for the included golang protobuf version and
     # see https://github.com/golang/protobuf/pull/544 for "paths=source_relative" usage
-    tag = "0.19.1",
+    tag = "v0.19.9",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -34,14 +34,33 @@ rules_proto_toolchains()
 # Import grpc for cc_grpc_library().
 http_archive(
     name = "com_github_grpc_grpc",
-    sha256 = "54130a7fa3dae57ed148f24cddcc91ff56e8023ed3d1e44cff4e1a922406087d",
-    strip_prefix = "grpc-809e7c951358a80182d7126b255c3a40881fb3fa",
-    urls = ["https://github.com/grpc/grpc/archive/809e7c951358a80182d7126b255c3a40881fb3fa.zip"],
+    #sha256 = "54130a7fa3dae57ed148f24cddcc91ff56e8023ed3d1e44cff4e1a922406087d",
+    strip_prefix = "grpc-b1547c9d19034740b1e5b4d73cb91d068dc0acb4",
+    urls = ["https://github.com/grpc/grpc/archive/b1547c9d19034740b1e5b4d73cb91d068dc0acb4.zip"],
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
-
 grpc_deps()
+
+# grpc_deps() cannot load() its deps, this WORKSPACE has to do it.
+# See also: https://github.com/bazelbuild/bazel/issues/1943
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
+load("@upb//bazel:repository_defs.bzl", "bazel_version_repository")
+
+bazel_version_repository(name = "bazel_version")
 
 # go rules related
 git_repository(

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -34,7 +34,7 @@ rules_proto_toolchains()
 # Import grpc for cc_grpc_library().
 http_archive(
     name = "com_github_grpc_grpc",
-    #sha256 = "54130a7fa3dae57ed148f24cddcc91ff56e8023ed3d1e44cff4e1a922406087d",
+    sha256 = "bbda0588df1b31aca41b83d09cf69816df653b5a89f820d16ab95af8eb1f9072",
     strip_prefix = "grpc-b1547c9d19034740b1e5b4d73cb91d068dc0acb4",
     urls = ["https://github.com/grpc/grpc/archive/b1547c9d19034740b1e5b4d73cb91d068dc0acb4.zip"],
 )

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -17,6 +17,20 @@ workspace(name = "opencensus_proto")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Import rules_proto for proto_library().
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
 # Import grpc for cc_grpc_library().
 http_archive(
     name = "com_github_grpc_grpc",

--- a/src/opencensus/proto/agent/common/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/common/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/agent/common/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/common/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -26,8 +28,8 @@ proto_library(
 
 go_proto_library(
     name = "common_proto_go",
-    proto = ":common_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1",
+    proto = ":common_proto",
     deps = [
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
     ],

--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/metrics/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -35,14 +37,14 @@ cc_proto_library(
 cc_grpc_library(
     name = "metrics_service_grpc_cc",
     srcs = [":metrics_service_proto"],
-    deps = [":metrics_service_proto_cc"],
     grpc_only = True,
+    deps = [":metrics_service_proto_cc"],
 )
 
 go_proto_library(
     name = "metrics_service_proto_go",
-    proto = ":metrics_service_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1",
+    proto = ":metrics_service_proto",
     deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/metrics/v1:metrics_proto_go",

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/agent/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/agent/trace/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -23,8 +25,8 @@ proto_library(
     deps = [
         "//opencensus/proto/agent/common/v1:common_proto",
         "//opencensus/proto/resource/v1:resource_proto",
-        "//opencensus/proto/trace/v1:trace_proto",
         "//opencensus/proto/trace/v1:trace_config_proto",
+        "//opencensus/proto/trace/v1:trace_proto",
     ],
 )
 
@@ -36,14 +38,14 @@ cc_proto_library(
 cc_grpc_library(
     name = "trace_service_grpc_cc",
     srcs = [":trace_service_proto"],
-    deps = [":trace_service_proto_cc"],
     grpc_only = True,
+    deps = [":trace_service_proto_cc"],
 )
 
 go_proto_library(
     name = "trace_service_proto_go",
-    proto = ":trace_service_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/agent/trace/v1",
+    proto = ":trace_service_proto",
     deps = [
         "//opencensus/proto/agent/common/v1:common_proto_go",
         "//opencensus/proto/resource/v1:resource_proto_go",

--- a/src/opencensus/proto/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/metrics/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/metrics/v1/BUILD.bazel
+++ b/src/opencensus/proto/metrics/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -20,9 +22,9 @@ proto_library(
     name = "metrics_proto",
     srcs = ["metrics.proto"],
     deps = [
+        "//opencensus/proto/resource/v1:resource_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
-        "//opencensus/proto/resource/v1:resource_proto",
     ],
 )
 
@@ -38,8 +40,8 @@ java_proto_library(
 
 go_proto_library(
     name = "metrics_proto_go",
-    proto = ":metrics_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1",
+    proto = ":metrics_proto",
     deps = [
         "//opencensus/proto/resource/v1:resource_proto_go",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",

--- a/src/opencensus/proto/resource/v1/BUILD.bazel
+++ b/src/opencensus/proto/resource/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/resource/v1/BUILD.bazel
+++ b/src/opencensus/proto/resource/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -34,8 +36,8 @@ java_proto_library(
 
 go_proto_library(
     name = "resource_proto_go",
-    proto = ":resource_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1",
+    proto = ":resource_proto",
 )
 
 py_proto_library(

--- a/src/opencensus/proto/stats/v1/BUILD.bazel
+++ b/src/opencensus/proto/stats/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -37,8 +39,8 @@ java_proto_library(
 
 go_proto_library(
     name = "stats_proto_go",
-    proto = ":stats_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/stats/v1",
+    proto = ":stats_proto",
     deps = [
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
     ],

--- a/src/opencensus/proto/stats/v1/BUILD.bazel
+++ b/src/opencensus/proto/stats/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/opencensus/proto/trace/v1/BUILD.bazel
+++ b/src/opencensus/proto/trace/v1/BUILD.bazel
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//third_party/bazel_rules/rules_proto/proto:defs.bzl", "proto_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -22,9 +24,9 @@ proto_library(
     name = "trace_proto",
     srcs = ["trace.proto"],
     deps = [
+        "//opencensus/proto/resource/v1:resource_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@com_google_protobuf//:wrappers_proto",
-        "//opencensus/proto/resource/v1:resource_proto",
     ],
 )
 
@@ -55,27 +57,27 @@ java_proto_library(
 
 go_proto_library(
     name = "trace_proto_go",
-    proto = ":trace_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
+    proto = ":trace_proto",
     deps = [
+        "//opencensus/proto/resource/v1:resource_proto_go",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-        "//opencensus/proto/resource/v1:resource_proto_go",
     ],
 )
 
 go_proto_library(
     name = "trace_config_proto_go",
-    proto = ":trace_config_proto",
     importpath = "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1",
+    proto = ":trace_config_proto",
 )
 
 py_proto_library(
     name = "trace_proto_py",
     srcs = ["trace.proto"],
     deps = [
-        "@com_google_protobuf//:protobuf_python",
         "//opencensus/proto/resource/v1:resource_proto_py",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 
@@ -94,5 +96,5 @@ go_library(
     embed = [
         ":trace_proto_go",
         ":trace_config_proto_go",
-    ]
+    ],
 )


### PR DESCRIPTION
Starting with Bazel 3.0, all Protobuf rules will require explicit load
statements.

Fixes #215.