### PR TITLE
update to grpc-gateway v2

### DIFF
--- a/gen-go/agent/metrics/v1/metrics_service.pb.gw.go
+++ b/gen-go/agent/metrics/v1/metrics_service.pb.gw.go
@@ -13,14 +13,14 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/grpc-ecosystem/grpc-gateway/utilities"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // Suppress "imported and not used" errors
@@ -29,7 +29,7 @@ var _ io.Reader
 var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
+var _ = metadata.Join
 
 func request_MetricsService_Export_0(ctx context.Context, marshaler runtime.Marshaler, client MetricsServiceClient, req *http.Request, pathParams map[string]string) (MetricsService_ExportClient, runtime.ServerMetadata, error) {
 	var metadata runtime.ServerMetadata
@@ -86,6 +86,7 @@ func request_MetricsService_Export_0(ctx context.Context, marshaler runtime.Mars
 // RegisterMetricsServiceHandlerServer registers the http handlers for service MetricsService to "mux".
 // UnaryRPC     :call MetricsServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterMetricsServiceHandlerFromEndpoint instead.
 func RegisterMetricsServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server MetricsServiceServer) error {
 
 	mux.Handle("POST", pattern_MetricsService_Export_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -140,7 +141,7 @@ func RegisterMetricsServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/opencensus.proto.agent.metrics.v1.MetricsService/Export")
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -160,7 +161,7 @@ func RegisterMetricsServiceHandlerClient(ctx context.Context, mux *runtime.Serve
 }
 
 var (
-	pattern_MetricsService_Export_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "metrics"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_MetricsService_Export_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "metrics"}, ""))
 )
 
 var (

--- a/gen-go/agent/trace/v1/trace_service.pb.gw.go
+++ b/gen-go/agent/trace/v1/trace_service.pb.gw.go
@@ -13,14 +13,14 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/grpc-ecosystem/grpc-gateway/utilities"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/utilities"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // Suppress "imported and not used" errors
@@ -29,7 +29,7 @@ var _ io.Reader
 var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
-var _ = descriptor.ForMessage
+var _ = metadata.Join
 
 func request_TraceService_Export_0(ctx context.Context, marshaler runtime.Marshaler, client TraceServiceClient, req *http.Request, pathParams map[string]string) (TraceService_ExportClient, runtime.ServerMetadata, error) {
 	var metadata runtime.ServerMetadata
@@ -86,6 +86,7 @@ func request_TraceService_Export_0(ctx context.Context, marshaler runtime.Marsha
 // RegisterTraceServiceHandlerServer registers the http handlers for service TraceService to "mux".
 // UnaryRPC     :call TraceServiceServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
+// Note that using this registration option will cause many gRPC library features to stop working. Consider using RegisterTraceServiceHandlerFromEndpoint instead.
 func RegisterTraceServiceHandlerServer(ctx context.Context, mux *runtime.ServeMux, server TraceServiceServer) error {
 
 	mux.Handle("POST", pattern_TraceService_Export_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
@@ -140,7 +141,7 @@ func RegisterTraceServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req, "/opencensus.proto.agent.trace.v1.TraceService/Export")
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -160,7 +161,7 @@ func RegisterTraceServiceHandlerClient(ctx context.Context, mux *runtime.ServeMu
 }
 
 var (
-	pattern_TraceService_Export_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "trace"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_TraceService_Export_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "trace"}, ""))
 )
 
 var (

--- a/gen-openapi/opencensus/proto/agent/metrics/v1/metrics_service.swagger.json
+++ b/gen-openapi/opencensus/proto/agent/metrics/v1/metrics_service.swagger.json
@@ -4,6 +4,10 @@
     "title": "opencensus/proto/agent/metrics/v1/metrics_service.proto",
     "version": "version not set"
   },
+  "schemes": [
+    "http",
+    "https"
+  ],
   "consumes": [
     "application/json"
   ],
@@ -14,27 +18,13 @@
     "/v1/metrics": {
       "post": {
         "summary": "For performance reasons, it is recommended to keep this RPC\nalive for the entire life of the application.",
-        "operationId": "MetricsService_Export",
+        "operationId": "Export",
         "responses": {
           "200": {
-            "description": "A successful response.(streaming responses)",
+            "description": "(streaming responses)",
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "$ref": "#/definitions/v1ExportMetricsServiceResponse"
-                },
-                "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
-                }
-              },
-              "title": "Stream result of v1ExportMetricsServiceResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response",
-            "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/v1ExportMetricsServiceResponse",
+              "additionalProperties": null
             }
           }
         },
@@ -45,7 +35,8 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ExportMetricsServiceRequest"
+              "$ref": "#/definitions/v1ExportMetricsServiceRequest",
+              "additionalProperties": null
             }
           }
         ],
@@ -65,9 +56,11 @@
             "type": "number",
             "format": "double"
           },
+          "additionalProperties": null,
           "description": "The values must be strictly increasing and \u003e 0."
         }
       },
+      "additionalProperties": null,
       "description": "[0, bucket_bounds[i]) for i == 0\n[bucket_bounds[i-1], bucket_bounds[i]) for 0 \u003c i \u003c N-1\n[bucket_bounds[i], +infinity) for i == N-1",
       "title": "Specifies a set of buckets with arbitrary upper-bounds.\nThis defines size(bounds) + 1 (= N) buckets. The boundaries for bucket\nindex i are:"
     },
@@ -77,22 +70,27 @@
         "count": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The number of values in each bucket of the histogram, as described in\nbucket_bounds."
         },
         "exemplar": {
           "$ref": "#/definitions/DistributionValueExemplar",
+          "additionalProperties": null,
           "description": "If the distribution does not have a histogram, then omit this field."
         }
-      }
+      },
+      "additionalProperties": null
     },
     "DistributionValueBucketOptions": {
       "type": "object",
       "properties": {
         "explicit": {
           "$ref": "#/definitions/BucketOptionsExplicit",
+          "additionalProperties": null,
           "description": "Bucket with explicit bounds."
         }
       },
+      "additionalProperties": null,
       "description": "A Distribution may optionally contain a histogram of the values in the\npopulation. The bucket boundaries for that histogram are described by\nBucketOptions.\n\nIf bucket_options has no type, then there is no histogram associated with\nthe Distribution."
     },
     "DistributionValueExemplar": {
@@ -101,21 +99,25 @@
         "value": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "Value of the exemplar point. It determines which bucket the exemplar\nbelongs to."
         },
         "timestamp": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "The observation (sampling) time of the above value."
         },
         "attachments": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "additionalProperties": null
           },
           "description": "Contextual information about the example value."
         }
       },
+      "additionalProperties": null,
       "description": "Exemplars are example points that may be used to annotate aggregated\nDistribution values. They are metadata that gives information about a\nparticular value added to a Distribution bucket."
     },
     "LibraryInfoLanguage": {
@@ -133,7 +135,8 @@
         "RUBY",
         "WEB_JS"
       ],
-      "default": "LANGUAGE_UNSPECIFIED"
+      "default": "LANGUAGE_UNSPECIFIED",
+      "additionalProperties": null
     },
     "MetricDescriptorType": {
       "type": "string",
@@ -148,6 +151,7 @@
         "SUMMARY"
       ],
       "default": "UNSPECIFIED",
+      "additionalProperties": null,
       "description": "The kind of metric. It describes how the data is reported.\n\nA gauge is an instantaneous measurement of a value.\n\nA cumulative measurement is a value accumulated over a time interval. In\na time series, cumulative measurements should have the same start time,\nincreasing values and increasing end times, until an event resets the\ncumulative value to zero and sets a new start time for the following\npoints.\n\n - UNSPECIFIED: Do not use this default value.\n - GAUGE_INT64: Integer gauge. The value can go both up and down.\n - GAUGE_DOUBLE: Floating point gauge. The value can go both up and down.\n - GAUGE_DISTRIBUTION: Distribution gauge measurement. The count and sum can go both up and\ndown. Recorded values are always \u003e= 0.\nUsed in scenarios like a snapshot of time the current items in a queue\nhave spent there.\n - CUMULATIVE_INT64: Integer cumulative measurement. The value cannot decrease, if resets\nthen the start_time should also be reset.\n - CUMULATIVE_DOUBLE: Floating point cumulative measurement. The value cannot decrease, if\nresets then the start_time should also be reset. Recorded values are\nalways \u003e= 0.\n - CUMULATIVE_DISTRIBUTION: Distribution cumulative measurement. The count and sum cannot decrease,\nif resets then the start_time should also be reset.\n - SUMMARY: Some frameworks implemented Histograms as a summary of observations\n(usually things like request durations and response sizes). While it\nalso provides a total count of observations and a sum of all observed\nvalues, it calculates configurable percentiles over a sliding time\nwindow. This is not recommended, since it cannot be aggregated."
     },
     "SnapshotValueAtPercentile": {
@@ -156,14 +160,17 @@
         "percentile": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The percentile of a distribution. Must be in the interval\n(0.0, 100.0]."
         },
         "value": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The value at the given percentile of a distribution."
         }
       },
+      "additionalProperties": null,
       "description": "Represents the value at a given percentile of a distribution."
     },
     "SummaryValueSnapshot": {
@@ -172,11 +179,13 @@
         "count": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The number of values in the snapshot. Optional since some systems don't\nexpose this."
         },
         "sum": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The sum of values in the snapshot. Optional since some systems don't\nexpose this. If count is zero then this field must be zero or not set\n(if not supported)."
         },
         "percentile_values": {
@@ -184,68 +193,12 @@
           "items": {
             "$ref": "#/definitions/SnapshotValueAtPercentile"
           },
+          "additionalProperties": null,
           "description": "A list of values at different percentiles of the distribution calculated\nfrom the current snapshot. The percentiles must be strictly increasing."
         }
       },
+      "additionalProperties": null,
       "description": "The values in this message can be reset at arbitrary unknown times, with\nthe requirement that all of them are reset at the same time."
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
-    "runtimeError": {
-      "type": "object",
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
     },
     "v1DistributionValue": {
       "type": "object",
@@ -253,21 +206,25 @@
         "count": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The number of values in the population. Must be non-negative. This value\nmust equal the sum of the values in bucket_counts if a histogram is\nprovided."
         },
         "sum": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The sum of the values in the population. If count is zero then this field\nmust be zero."
         },
         "sum_of_squared_deviation": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "Sum[i=1..n]((x_i - mean)^2)\n\nKnuth, \"The Art of Computer Programming\", Vol. 2, page 323, 3rd edition\ndescribes Welford's method for accumulating this sum in one pass.\n\nIf count is zero then this field must be zero.",
           "title": "The sum of squared deviations from the mean of the values in the\npopulation. For values x_i this is:"
         },
         "bucket_options": {
           "$ref": "#/definitions/DistributionValueBucketOptions",
+          "additionalProperties": null,
           "description": "Don't change bucket boundaries within a TimeSeries if your backend doesn't\nsupport this.\nTODO(issue #152): consider not required to send bucket options for\noptimization."
         },
         "buckets": {
@@ -275,9 +232,11 @@
           "items": {
             "$ref": "#/definitions/DistributionValueBucket"
           },
+          "additionalProperties": null,
           "description": "If the distribution does not have a histogram, then omit this field.\nIf there is a histogram, then the sum of the values in the Bucket counts\nmust equal the value in the count field of the distribution."
         }
       },
+      "additionalProperties": null,
       "description": "Distribution contains summary statistics for a population of values. It\noptionally contains a histogram representing the distribution of those\nvalues across a set of buckets."
     },
     "v1ExportMetricsServiceRequest": {
@@ -285,6 +244,7 @@
       "properties": {
         "node": {
           "$ref": "#/definitions/v1Node",
+          "additionalProperties": null,
           "description": "This is required only in the first message on the stream or if the\nprevious sent ExportMetricsServiceRequest message has a different Node (e.g.\nwhen the same RPC is used to send Metrics from multiple Applications)."
         },
         "metrics": {
@@ -292,29 +252,36 @@
           "items": {
             "$ref": "#/definitions/v1Metric"
           },
+          "additionalProperties": null,
           "description": "A list of metrics that belong to the last received Node."
         },
         "resource": {
           "$ref": "#/definitions/v1Resource",
+          "additionalProperties": null,
           "description": "The resource for the metrics in this message that do not have an explicit\nresource set.\nIf unset, the most recently set resource in the RPC stream applies. It is\nvalid to never be set within a stream, e.g. when no resource info is known\nat all or when all sent metrics have an explicit resource set."
         }
-      }
+      },
+      "additionalProperties": null
     },
     "v1ExportMetricsServiceResponse": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": null
     },
     "v1LabelKey": {
       "type": "object",
       "properties": {
         "key": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The key for the label."
         },
         "description": {
           "type": "string",
+          "additionalProperties": null,
           "description": "A human-readable description of what this label key represents."
         }
       },
+      "additionalProperties": null,
       "description": "Defines a label key associated with a metric descriptor."
     },
     "v1LabelValue": {
@@ -322,31 +289,38 @@
       "properties": {
         "value": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The value for the label."
         },
         "has_value": {
           "type": "boolean",
           "format": "boolean",
+          "additionalProperties": null,
           "description": "If false the value field is ignored and considered not set.\nThis is used to differentiate a missing label from an empty string."
         }
-      }
+      },
+      "additionalProperties": null
     },
     "v1LibraryInfo": {
       "type": "object",
       "properties": {
         "language": {
           "$ref": "#/definitions/LibraryInfoLanguage",
+          "additionalProperties": null,
           "description": "Language of OpenCensus Library."
         },
         "exporter_version": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Version of Agent exporter of Library."
         },
         "core_library_version": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Version of OpenCensus Library."
         }
       },
+      "additionalProperties": null,
       "description": "Information on OpenCensus Library."
     },
     "v1Metric": {
@@ -354,6 +328,7 @@
       "properties": {
         "metric_descriptor": {
           "$ref": "#/definitions/v1MetricDescriptor",
+          "additionalProperties": null,
           "description": "The descriptor of the Metric.\nTODO(issue #152): consider only sending the name of descriptor for\noptimization."
         },
         "timeseries": {
@@ -361,13 +336,16 @@
           "items": {
             "$ref": "#/definitions/v1TimeSeries"
           },
+          "additionalProperties": null,
           "description": "One or more timeseries for a single metric, where each timeseries has\none or more points."
         },
         "resource": {
           "$ref": "#/definitions/v1Resource",
+          "additionalProperties": null,
           "description": "The resource for the metric. If unset, it may be set to a default value\nprovided for a sequence of messages in an RPC stream."
         }
       },
+      "additionalProperties": null,
       "description": "Defines a Metric which has one or more timeseries."
     },
     "v1MetricDescriptor": {
@@ -375,27 +353,33 @@
       "properties": {
         "name": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The metric type, including its DNS name prefix. It must be unique."
         },
         "description": {
           "type": "string",
+          "additionalProperties": null,
           "description": "A detailed description of the metric, which can be used in documentation."
         },
         "unit": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The unit in which the metric value is reported. Follows the format\ndescribed by http://unitsofmeasure.org/ucum.html."
         },
         "type": {
-          "$ref": "#/definitions/MetricDescriptorType"
+          "$ref": "#/definitions/MetricDescriptorType",
+          "additionalProperties": null
         },
         "label_keys": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/v1LabelKey"
           },
+          "additionalProperties": null,
           "description": "The label keys associated with the metric descriptor."
         }
       },
+      "additionalProperties": null,
       "description": "Defines a metric type and its schema."
     },
     "v1Node": {
@@ -403,24 +387,29 @@
       "properties": {
         "identifier": {
           "$ref": "#/definitions/v1ProcessIdentifier",
+          "additionalProperties": null,
           "description": "Identifier that uniquely identifies a process within a VM/container."
         },
         "library_info": {
           "$ref": "#/definitions/v1LibraryInfo",
+          "additionalProperties": null,
           "description": "Information on the OpenCensus Library that initiates the stream."
         },
         "service_info": {
           "$ref": "#/definitions/v1ServiceInfo",
+          "additionalProperties": null,
           "description": "Additional information on service."
         },
         "attributes": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "additionalProperties": null
           },
           "description": "Additional attributes."
         }
       },
+      "additionalProperties": null,
       "title": "Identifier metadata of the Node that produces the span or tracing data.\nNote, this is not the metadata about the Node or service that is described by associated spans.\nIn the future we plan to extend the identifier proto definition to support\nadditional information (e.g cloud id, etc.)"
     },
     "v1Point": {
@@ -429,27 +418,33 @@
         "timestamp": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "The moment when this point was recorded. Inclusive.\nIf not specified, the timestamp will be decided by the backend."
         },
         "int64_value": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "A 64-bit integer."
         },
         "double_value": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "A 64-bit double-precision floating-point number."
         },
         "distribution_value": {
           "$ref": "#/definitions/v1DistributionValue",
+          "additionalProperties": null,
           "description": "A distribution value."
         },
         "summary_value": {
           "$ref": "#/definitions/v1SummaryValue",
+          "additionalProperties": null,
           "description": "A summary value. This is not recommended, since it cannot be aggregated."
         }
       },
+      "additionalProperties": null,
       "description": "A timestamped measurement."
     },
     "v1ProcessIdentifier": {
@@ -457,19 +452,23 @@
       "properties": {
         "host_name": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The host name. Usually refers to the machine/container name.\nFor example: os.Hostname() in Go, socket.gethostname() in Python."
         },
         "pid": {
           "type": "integer",
           "format": "int64",
+          "additionalProperties": null,
           "description": "Process id."
         },
         "start_timestamp": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "Start time of this ProcessIdentifier. Represented in epoch time."
         }
       },
+      "additionalProperties": null,
       "description": "Identifier that uniquely identifies a process within a VM/container."
     },
     "v1Resource": {
@@ -477,16 +476,19 @@
       "properties": {
         "type": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Type identifier for the resource."
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "additionalProperties": null
           },
           "description": "Set of labels that describe the resource."
         }
       },
+      "additionalProperties": null,
       "description": "Resource information."
     },
     "v1ServiceInfo": {
@@ -494,9 +496,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Name of the service."
         }
       },
+      "additionalProperties": null,
       "description": "Additional service information."
     },
     "v1SummaryValue": {
@@ -505,18 +509,22 @@
         "count": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The total number of recorded values since start_time. Optional since\nsome systems don't expose this."
         },
         "sum": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The total sum of recorded values since start_time. Optional since some\nsystems don't expose this. If count is zero then this field must be zero.\nThis field must be unset if the sum is not available."
         },
         "snapshot": {
           "$ref": "#/definitions/SummaryValueSnapshot",
+          "additionalProperties": null,
           "description": "Values calculated over an arbitrary time window."
         }
       },
+      "additionalProperties": null,
       "description": "The start_timestamp only applies to the count and sum in the SummaryValue."
     },
     "v1TimeSeries": {
@@ -525,6 +533,7 @@
         "start_timestamp": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "Must be present for cumulative metrics. The time when the cumulative value\nwas reset to zero. Exclusive. The cumulative value is over the time interval\n(start_timestamp, timestamp]. If not specified, the backend can use the\nprevious recorded value."
         },
         "label_values": {
@@ -532,6 +541,7 @@
           "items": {
             "$ref": "#/definitions/v1LabelValue"
           },
+          "additionalProperties": null,
           "description": "The set of label values that uniquely identify this timeseries. Applies to\nall points. The order of label values must match that of label keys in the\nmetric descriptor."
         },
         "points": {
@@ -539,9 +549,11 @@
           "items": {
             "$ref": "#/definitions/v1Point"
           },
+          "additionalProperties": null,
           "description": "The data points of this timeseries. Point.value type MUST match the\nMetricDescriptor.type."
         }
       },
+      "additionalProperties": null,
       "description": "A collection of data points that describes the time-varying values\nof a metric."
     }
   }

--- a/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json
+++ b/gen-openapi/opencensus/proto/agent/trace/v1/trace_service.swagger.json
@@ -4,6 +4,10 @@
     "title": "opencensus/proto/agent/trace/v1/trace_service.proto",
     "version": "version not set"
   },
+  "schemes": [
+    "http",
+    "https"
+  ],
   "consumes": [
     "application/json"
   ],
@@ -14,27 +18,13 @@
     "/v1/trace": {
       "post": {
         "summary": "For performance reasons, it is recommended to keep this RPC\nalive for the entire life of the application.",
-        "operationId": "TraceService_Export",
+        "operationId": "Export",
         "responses": {
           "200": {
-            "description": "A successful response.(streaming responses)",
+            "description": "(streaming responses)",
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "$ref": "#/definitions/v1ExportTraceServiceResponse"
-                },
-                "error": {
-                  "$ref": "#/definitions/runtimeStreamError"
-                }
-              },
-              "title": "Stream result of v1ExportTraceServiceResponse"
-            }
-          },
-          "default": {
-            "description": "An unexpected error response",
-            "schema": {
-              "$ref": "#/definitions/runtimeError"
+              "$ref": "#/definitions/v1ExportTraceServiceResponse",
+              "additionalProperties": null
             }
           }
         },
@@ -45,7 +35,8 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/v1ExportTraceServiceRequest"
+              "$ref": "#/definitions/v1ExportTraceServiceRequest",
+              "additionalProperties": null
             }
           }
         ],
@@ -64,6 +55,7 @@
         "ALWAYS_PARENT"
       ],
       "default": "ALWAYS_OFF",
+      "additionalProperties": null,
       "description": "How spans should be sampled:\n- Always off\n- Always on\n- Always follow the parent Span's decision (off if no parent)."
     },
     "LibraryInfoLanguage": {
@@ -81,7 +73,8 @@
         "RUBY",
         "WEB_JS"
       ],
-      "default": "LANGUAGE_UNSPECIFIED"
+      "default": "LANGUAGE_UNSPECIFIED",
+      "additionalProperties": null
     },
     "SpanAttributes": {
       "type": "object",
@@ -89,7 +82,8 @@
         "attribute_map": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/v1AttributeValue"
+            "$ref": "#/definitions/v1AttributeValue",
+            "additionalProperties": null
           },
           "description": "\"/http/user_agent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36\"\n    \"/http/server_latency\": 300\n    \"abc.com/myattribute\": true\n    \"abc.com/score\": 10.239",
           "title": "The set of attributes. The value can be a string, an integer, a double\nor the Boolean values `true` or `false`. Note, global attributes like \nserver name can be set as tags using resource API. Examples of attributes:"
@@ -97,9 +91,11 @@
         "dropped_attributes_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of attributes that were discarded. Attributes can be discarded\nbecause their keys are too long or because there are too many attributes.\nIf this value is 0, then no attributes were dropped."
         }
       },
+      "additionalProperties": null,
       "description": "A set of attributes, each with a key and a value."
     },
     "SpanLink": {
@@ -108,26 +104,32 @@
         "trace_id": {
           "type": "string",
           "format": "byte",
+          "additionalProperties": null,
           "description": "A unique identifier of a trace that this linked span is part of. The ID is a \n16-byte array."
         },
         "span_id": {
           "type": "string",
           "format": "byte",
+          "additionalProperties": null,
           "description": "A unique identifier for the linked span. The ID is an 8-byte array."
         },
         "type": {
           "$ref": "#/definitions/SpanLinkType",
+          "additionalProperties": null,
           "description": "The relationship of the current span relative to the linked span."
         },
         "attributes": {
           "$ref": "#/definitions/SpanAttributes",
+          "additionalProperties": null,
           "description": "A set of attributes on the link."
         },
         "tracestate": {
           "$ref": "#/definitions/SpanTracestate",
+          "additionalProperties": null,
           "description": "The Tracestate associated with the link."
         }
       },
+      "additionalProperties": null,
       "description": "A pointer from the current span to another span in the same trace or in a\ndifferent trace. For example, this can be used in batching operations,\nwhere a single batch handler processes multiple requests from different\ntraces or when the handler receives a request from a different project."
     },
     "SpanLinkType": {
@@ -138,6 +140,7 @@
         "PARENT_LINKED_SPAN"
       ],
       "default": "TYPE_UNSPECIFIED",
+      "additionalProperties": null,
       "description": "The relationship of the current span relative to the linked span: child,\nparent, or unspecified.\n\n - TYPE_UNSPECIFIED: The relationship of the two spans is unknown, or known but other\nthan parent-child.\n - CHILD_LINKED_SPAN: The linked span is a child of the current span.\n - PARENT_LINKED_SPAN: The linked span is a parent of the current span."
     },
     "SpanLinks": {
@@ -148,14 +151,17 @@
           "items": {
             "$ref": "#/definitions/SpanLink"
           },
+          "additionalProperties": null,
           "description": "A collection of links."
         },
         "dropped_links_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of dropped links after the maximum size was enforced. If\nthis value is 0, then no links were dropped."
         }
       },
+      "additionalProperties": null,
       "description": "A collection of links, which are references from this span to a span\nin the same or different trace."
     },
     "SpanSpanKind": {
@@ -166,6 +172,7 @@
         "CLIENT"
       ],
       "default": "SPAN_KIND_UNSPECIFIED",
+      "additionalProperties": null,
       "description": "Type of span. Can be used to specify additional relationships between spans\nin addition to a parent/child relationship.\n\n - SPAN_KIND_UNSPECIFIED: Unspecified.\n - SERVER: Indicates that the span covers server-side handling of an RPC or other\nremote network request.\n - CLIENT: Indicates that the span covers the client-side wrapper around an RPC or\nother remote request."
     },
     "SpanTimeEvent": {
@@ -174,17 +181,21 @@
         "time": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "The time the event occurred."
         },
         "annotation": {
           "$ref": "#/definitions/TimeEventAnnotation",
+          "additionalProperties": null,
           "description": "A text annotation with a set of attributes."
         },
         "message_event": {
           "$ref": "#/definitions/TimeEventMessageEvent",
+          "additionalProperties": null,
           "description": "An event describing a message sent/received between Spans."
         }
       },
+      "additionalProperties": null,
       "description": "A time-stamped annotation or message event in the Span."
     },
     "SpanTimeEvents": {
@@ -195,19 +206,23 @@
           "items": {
             "$ref": "#/definitions/SpanTimeEvent"
           },
+          "additionalProperties": null,
           "description": "A collection of `TimeEvent`s."
         },
         "dropped_annotations_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of dropped annotations in all the included time events.\nIf the value is 0, then no annotations were dropped."
         },
         "dropped_message_events_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of dropped message events in all the included time events.\nIf the value is 0, then no message events were dropped."
         }
       },
+      "additionalProperties": null,
       "description": "A collection of `TimeEvent`s. A `TimeEvent` is a time-stamped annotation\non the span, consisting of either user-supplied key-value pairs, or\ndetails of a message sent/received between Spans."
     },
     "SpanTracestate": {
@@ -218,9 +233,11 @@
           "items": {
             "$ref": "#/definitions/TracestateEntry"
           },
+          "additionalProperties": null,
           "description": "A list of entries that represent the Tracestate."
         }
       },
+      "additionalProperties": null,
       "description": "This field conveys information about request position in multiple distributed tracing graphs.\nIt is a list of Tracestate.Entry with a maximum of 32 members in the list.\n\nSee the https://github.com/w3c/distributed-tracing for more details about this field."
     },
     "StackTraceStackFrame": {
@@ -228,35 +245,43 @@
       "properties": {
         "function_name": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "The fully-qualified name that uniquely identifies the function or\nmethod that is active in this frame."
         },
         "original_function_name": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "An un-mangled function name, if `function_name` is\n[mangled](http://www.avabodh.com/cxxin/namemangling.html). The name can\nbe fully qualified."
         },
         "file_name": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "The name of the source file where the function call appears."
         },
         "line_number": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The line number in `file_name` where the function call appears."
         },
         "column_number": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The column number where the function call appears, if available.\nThis is important in JavaScript because of its anonymous functions."
         },
         "load_module": {
           "$ref": "#/definitions/v1Module",
+          "additionalProperties": null,
           "description": "The binary module from where the code was loaded."
         },
         "source_version": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "The version of the deployed source code."
         }
       },
+      "additionalProperties": null,
       "description": "A single stack frame in a stack trace."
     },
     "StackTraceStackFrames": {
@@ -267,14 +292,17 @@
           "items": {
             "$ref": "#/definitions/StackTraceStackFrame"
           },
+          "additionalProperties": null,
           "description": "Stack frames in this call stack."
         },
         "dropped_frames_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of stack frames that were dropped because there\nwere too many stack frames.\nIf this value is 0, then no stack frames were dropped."
         }
       },
+      "additionalProperties": null,
       "description": "A collection of stack frames, which can be truncated."
     },
     "TimeEventAnnotation": {
@@ -282,13 +310,16 @@
       "properties": {
         "description": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "A user-supplied message describing the event."
         },
         "attributes": {
           "$ref": "#/definitions/SpanAttributes",
+          "additionalProperties": null,
           "description": "A set of attributes on the annotation."
         }
       },
+      "additionalProperties": null,
       "description": "A text annotation with a set of attributes."
     },
     "TimeEventMessageEvent": {
@@ -296,24 +327,29 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/TimeEventMessageEventType",
+          "additionalProperties": null,
           "description": "The type of MessageEvent. Indicates whether the message was sent or\nreceived."
         },
         "id": {
           "type": "string",
           "format": "uint64",
+          "additionalProperties": null,
           "description": "An identifier for the MessageEvent's message that can be used to match\nSENT and RECEIVED MessageEvents. For example, this field could\nrepresent a sequence ID for a streaming RPC. It is recommended to be\nunique within a Span."
         },
         "uncompressed_size": {
           "type": "string",
           "format": "uint64",
+          "additionalProperties": null,
           "description": "The number of uncompressed bytes sent or received."
         },
         "compressed_size": {
           "type": "string",
           "format": "uint64",
+          "additionalProperties": null,
           "description": "The number of compressed bytes sent or received. If zero, assumed to\nbe the same size as uncompressed."
         }
       },
+      "additionalProperties": null,
       "description": "An event describing a message sent/received between Spans."
     },
     "TimeEventMessageEventType": {
@@ -324,6 +360,7 @@
         "RECEIVED"
       ],
       "default": "TYPE_UNSPECIFIED",
+      "additionalProperties": null,
       "description": "Indicates whether the message was sent or received.\n\n - TYPE_UNSPECIFIED: Unknown event type.\n - SENT: Indicates a sent message.\n - RECEIVED: Indicates a received message."
     },
     "TracestateEntry": {
@@ -331,104 +368,56 @@
       "properties": {
         "key": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The key must begin with a lowercase letter, and can only contain\nlowercase letters 'a'-'z', digits '0'-'9', underscores '_', dashes\n'-', asterisks '*', and forward slashes '/'."
         },
         "value": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The value is opaque string up to 256 characters printable ASCII\nRFC0020 characters (i.e., the range 0x20 to 0x7E) except ',' and '='.\nNote that this also excludes tabs, newlines, carriage returns, etc."
         }
-      }
-    },
-    "protobufAny": {
-      "type": "object",
-      "properties": {
-        "type_url": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string",
-          "format": "byte"
-        }
-      }
-    },
-    "runtimeError": {
-      "type": "object",
-      "properties": {
-        "error": {
-          "type": "string"
-        },
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
-    },
-    "runtimeStreamError": {
-      "type": "object",
-      "properties": {
-        "grpc_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "http_code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        },
-        "http_status": {
-          "type": "string"
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/protobufAny"
-          }
-        }
-      }
+      },
+      "additionalProperties": null
     },
     "v1AttributeValue": {
       "type": "object",
       "properties": {
         "string_value": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "A string up to 256 bytes long."
         },
         "int_value": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "A 64-bit signed integer."
         },
         "bool_value": {
           "type": "boolean",
           "format": "boolean",
+          "additionalProperties": null,
           "description": "A Boolean value represented by `true` or `false`."
         },
         "double_value": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "A double value."
         }
       },
+      "additionalProperties": null,
       "description": "The value of an Attribute."
     },
     "v1ConstantSampler": {
       "type": "object",
       "properties": {
         "decision": {
-          "$ref": "#/definitions/ConstantSamplerConstantDecision"
+          "$ref": "#/definitions/ConstantSamplerConstantDecision",
+          "additionalProperties": null
         }
       },
+      "additionalProperties": null,
       "description": "Sampler that always makes a constant decision on span sampling."
     },
     "v1ExportTraceServiceRequest": {
@@ -436,6 +425,7 @@
       "properties": {
         "node": {
           "$ref": "#/definitions/v1Node",
+          "additionalProperties": null,
           "description": "This is required only in the first message on the stream or if the\nprevious sent ExportTraceServiceRequest message has a different Node (e.g.\nwhen the same RPC is used to send Spans from multiple Applications)."
         },
         "spans": {
@@ -443,33 +433,41 @@
           "items": {
             "$ref": "#/definitions/v1Span"
           },
+          "additionalProperties": null,
           "description": "A list of Spans that belong to the last received Node."
         },
         "resource": {
           "$ref": "#/definitions/v1Resource",
+          "additionalProperties": null,
           "description": "The resource for the spans in this message that do not have an explicit\nresource set.\nIf unset, the most recently set resource in the RPC stream applies. It is\nvalid to never be set within a stream, e.g. when no resource info is known."
         }
-      }
+      },
+      "additionalProperties": null
     },
     "v1ExportTraceServiceResponse": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": null
     },
     "v1LibraryInfo": {
       "type": "object",
       "properties": {
         "language": {
           "$ref": "#/definitions/LibraryInfoLanguage",
+          "additionalProperties": null,
           "description": "Language of OpenCensus Library."
         },
         "exporter_version": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Version of Agent exporter of Library."
         },
         "core_library_version": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Version of OpenCensus Library."
         }
       },
+      "additionalProperties": null,
       "description": "Information on OpenCensus Library."
     },
     "v1Module": {
@@ -477,13 +475,16 @@
       "properties": {
         "module": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "TODO: document the meaning of this field.\nFor example: main binary, kernel modules, and dynamic libraries\nsuch as libc.so, sharedlib.so."
         },
         "build_id": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "A unique identifier for the module, usually a hash of its\ncontents."
         }
       },
+      "additionalProperties": null,
       "description": "A description of a binary module."
     },
     "v1Node": {
@@ -491,24 +492,29 @@
       "properties": {
         "identifier": {
           "$ref": "#/definitions/v1ProcessIdentifier",
+          "additionalProperties": null,
           "description": "Identifier that uniquely identifies a process within a VM/container."
         },
         "library_info": {
           "$ref": "#/definitions/v1LibraryInfo",
+          "additionalProperties": null,
           "description": "Information on the OpenCensus Library that initiates the stream."
         },
         "service_info": {
           "$ref": "#/definitions/v1ServiceInfo",
+          "additionalProperties": null,
           "description": "Additional information on service."
         },
         "attributes": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "additionalProperties": null
           },
           "description": "Additional attributes."
         }
       },
+      "additionalProperties": null,
       "title": "Identifier metadata of the Node that produces the span or tracing data.\nNote, this is not the metadata about the Node or service that is described by associated spans.\nIn the future we plan to extend the identifier proto definition to support\nadditional information (e.g cloud id, etc.)"
     },
     "v1ProbabilitySampler": {
@@ -517,9 +523,11 @@
         "samplingProbability": {
           "type": "number",
           "format": "double",
+          "additionalProperties": null,
           "description": "The desired probability of sampling. Must be within [0.0, 1.0]."
         }
       },
+      "additionalProperties": null,
       "description": "Sampler that tries to uniformly sample traces with a given probability.\nThe probability of sampling a trace is equal to that of the specified probability."
     },
     "v1ProcessIdentifier": {
@@ -527,19 +535,23 @@
       "properties": {
         "host_name": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The host name. Usually refers to the machine/container name.\nFor example: os.Hostname() in Go, socket.gethostname() in Python."
         },
         "pid": {
           "type": "integer",
           "format": "int64",
+          "additionalProperties": null,
           "description": "Process id."
         },
         "start_timestamp": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "Start time of this ProcessIdentifier. Represented in epoch time."
         }
       },
+      "additionalProperties": null,
       "description": "Identifier that uniquely identifies a process within a VM/container."
     },
     "v1RateLimitingSampler": {
@@ -548,9 +560,11 @@
         "qps": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "Rate per second."
         }
       },
+      "additionalProperties": null,
       "description": "Sampler that tries to sample with a rate per time window."
     },
     "v1Resource": {
@@ -558,16 +572,19 @@
       "properties": {
         "type": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Type identifier for the resource."
         },
         "labels": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "additionalProperties": null
           },
           "description": "Set of labels that describe the resource."
         }
       },
+      "additionalProperties": null,
       "description": "Resource information."
     },
     "v1ServiceInfo": {
@@ -575,9 +592,11 @@
       "properties": {
         "name": {
           "type": "string",
+          "additionalProperties": null,
           "description": "Name of the service."
         }
       },
+      "additionalProperties": null,
       "description": "Additional service information."
     },
     "v1Span": {
@@ -586,75 +605,92 @@
         "trace_id": {
           "type": "string",
           "format": "byte",
+          "additionalProperties": null,
           "description": "A unique identifier for a trace. All spans from the same trace share\nthe same `trace_id`. The ID is a 16-byte array. An ID with all zeroes\nis considered invalid.\n\nThis field is semantically required. Receiver should generate new\nrandom trace_id if empty or invalid trace_id was received.\n\nThis field is required."
         },
         "span_id": {
           "type": "string",
           "format": "byte",
+          "additionalProperties": null,
           "description": "A unique identifier for a span within a trace, assigned when the span\nis created. The ID is an 8-byte array. An ID with all zeroes is considered\ninvalid.\n\nThis field is semantically required. Receiver should generate new\nrandom span_id if empty or invalid span_id was received.\n\nThis field is required."
         },
         "tracestate": {
           "$ref": "#/definitions/SpanTracestate",
+          "additionalProperties": null,
           "description": "The Tracestate on the span."
         },
         "parent_span_id": {
           "type": "string",
           "format": "byte",
+          "additionalProperties": null,
           "description": "The `span_id` of this span's parent span. If this is a root span, then this\nfield must be empty. The ID is an 8-byte array."
         },
         "name": {
           "$ref": "#/definitions/v1TruncatableString",
+          "additionalProperties": null,
           "description": "A description of the span's operation.\n\nFor example, the name can be a qualified method name or a file name\nand a line number where the operation is called. A best practice is to use\nthe same display name at the same call point in an application.\nThis makes it easier to correlate spans in different traces.\n\nThis field is semantically required to be set to non-empty string.\nWhen null or empty string received - receiver may use string \"name\"\nas a replacement. There might be smarted algorithms implemented by\nreceiver to fix the empty span name.\n\nThis field is required."
         },
         "kind": {
           "$ref": "#/definitions/SpanSpanKind",
+          "additionalProperties": null,
           "description": "Distinguishes between spans generated in a particular context. For example,\ntwo spans with the same name may be distinguished using `CLIENT` (caller)\nand `SERVER` (callee) to identify queueing latency associated with the span."
         },
         "start_time": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "The start time of the span. On the client side, this is the time kept by\nthe local machine where the span execution starts. On the server side, this\nis the time when the server's application handler starts running.\n\nThis field is semantically required. When not set on receive -\nreceiver should set it to the value of end_time field if it was\nset. Or to the current time if neither was set. It is important to\nkeep end_time \u003e start_time for consistency.\n\nThis field is required."
         },
         "end_time": {
           "type": "string",
           "format": "date-time",
+          "additionalProperties": null,
           "description": "The end time of the span. On the client side, this is the time kept by\nthe local machine where the span execution ends. On the server side, this\nis the time when the server application handler stops running.\n\nThis field is semantically required. When not set on receive -\nreceiver should set it to start_time value. It is important to\nkeep end_time \u003e start_time for consistency.\n\nThis field is required."
         },
         "attributes": {
           "$ref": "#/definitions/SpanAttributes",
+          "additionalProperties": null,
           "description": "A set of attributes on the span."
         },
         "stack_trace": {
           "$ref": "#/definitions/v1StackTrace",
+          "additionalProperties": null,
           "description": "A stack trace captured at the start of the span."
         },
         "time_events": {
           "$ref": "#/definitions/SpanTimeEvents",
+          "additionalProperties": null,
           "description": "The included time events."
         },
         "links": {
           "$ref": "#/definitions/SpanLinks",
+          "additionalProperties": null,
           "description": "The included links."
         },
         "status": {
           "$ref": "#/definitions/v1Status",
+          "additionalProperties": null,
           "description": "An optional final status for this span. Semantically when Status\nwasn't set it is means span ended without errors and assume\nStatus.Ok (code = 0)."
         },
         "resource": {
           "$ref": "#/definitions/v1Resource",
+          "additionalProperties": null,
           "description": "An optional resource that is associated with this span. If not set, this span \nshould be part of a batch that does include the resource information, unless resource \ninformation is unknown."
         },
         "same_process_as_parent_span": {
           "type": "boolean",
           "format": "boolean",
+          "additionalProperties": null,
           "description": "A highly recommended but not required flag that identifies when a\ntrace crosses a process boundary. True when the parent_span belongs\nto the same process as the current span. This flag is most commonly\nused to indicate the need to adjust time as clocks in different\nprocesses may not be synchronized."
         },
         "child_span_count": {
           "type": "integer",
           "format": "int64",
+          "additionalProperties": null,
           "description": "An optional number of child spans that were generated while this span\nwas active. If set, allows an implementation to detect missing child spans."
         }
       },
+      "additionalProperties": null,
       "description": "A span represents a single operation within a trace. Spans can be\nnested to form a trace tree. Spans may also be linked to other spans\nfrom the same or different trace. And form graphs. Often, a trace\ncontains a root span that describes the end-to-end latency, and one\nor more subspans for its sub-operations. A trace can also contain\nmultiple root spans, or none at all. Spans do not need to be\ncontiguous - there may be gaps or overlaps between spans in a trace.\n\nThe next id is 17.\nTODO(bdrutu): Add an example."
     },
     "v1StackTrace": {
@@ -662,14 +698,17 @@
       "properties": {
         "stack_frames": {
           "$ref": "#/definitions/StackTraceStackFrames",
+          "additionalProperties": null,
           "description": "Stack frames in this stack trace."
         },
         "stack_trace_hash_id": {
           "type": "string",
           "format": "uint64",
+          "additionalProperties": null,
           "description": "The hash ID is used to conserve network bandwidth for duplicate\nstack traces within a single trace.\n\nOften multiple spans will have identical stack traces.\nThe first occurrence of a stack trace should contain both\n`stack_frames` and a value in `stack_trace_hash_id`.\n\nSubsequent spans within the same request can refer\nto that stack trace by setting only `stack_trace_hash_id`.\n\nTODO: describe how to deal with the case where stack_trace_hash_id is\nzero because it was not set."
         }
       },
+      "additionalProperties": null,
       "description": "The call stack which originated this span."
     },
     "v1Status": {
@@ -678,48 +717,59 @@
         "code": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The status code. This is optional field. It is safe to assume 0 (OK)\nwhen not set."
         },
         "message": {
           "type": "string",
+          "additionalProperties": null,
           "description": "A developer-facing error message, which should be in English."
         }
       },
+      "additionalProperties": null,
       "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. This proto's fields\nare a subset of those of\n[google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto),\nwhich is used by [gRPC](https://github.com/grpc)."
     },
     "v1TraceConfig": {
       "type": "object",
       "properties": {
         "probability_sampler": {
-          "$ref": "#/definitions/v1ProbabilitySampler"
+          "$ref": "#/definitions/v1ProbabilitySampler",
+          "additionalProperties": null
         },
         "constant_sampler": {
-          "$ref": "#/definitions/v1ConstantSampler"
+          "$ref": "#/definitions/v1ConstantSampler",
+          "additionalProperties": null
         },
         "rate_limiting_sampler": {
-          "$ref": "#/definitions/v1RateLimitingSampler"
+          "$ref": "#/definitions/v1RateLimitingSampler",
+          "additionalProperties": null
         },
         "max_number_of_attributes": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The global default max number of attributes per span."
         },
         "max_number_of_annotations": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The global default max number of annotation events per span."
         },
         "max_number_of_message_events": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The global default max number of message events per span."
         },
         "max_number_of_links": {
           "type": "string",
           "format": "int64",
+          "additionalProperties": null,
           "description": "The global default max number of link entries per span."
         }
       },
+      "additionalProperties": null,
       "description": "Global configuration of the trace service. All fields must be specified, or\nthe default (zero) values will be used for each type."
     },
     "v1TruncatableString": {
@@ -727,14 +777,17 @@
       "properties": {
         "value": {
           "type": "string",
+          "additionalProperties": null,
           "description": "The shortened string. For example, if the original string was 500 bytes long and\nthe limit of the string was 128 bytes, then this value contains the first 128\nbytes of the 500-byte string. Note that truncation always happens on a\ncharacter boundary, to ensure that a truncated string is still valid UTF-8.\nBecause it may contain multi-byte characters, the size of the truncated string\nmay be less than the truncation limit."
         },
         "truncated_byte_count": {
           "type": "integer",
           "format": "int32",
+          "additionalProperties": null,
           "description": "The number of bytes removed from the original string. If this\nvalue is 0, then the string was not shortened."
         }
       },
+      "additionalProperties": null,
       "description": "A string that might be shortened to a specified length."
     },
     "v1UpdatedLibraryConfig": {
@@ -742,13 +795,16 @@
       "properties": {
         "node": {
           "$ref": "#/definitions/v1Node",
+          "additionalProperties": null,
           "description": "This field is ignored when the RPC is used to configure only one Application.\nThis is required only in the first message on the stream or if the\nprevious sent UpdatedLibraryConfig message has a different Node."
         },
         "config": {
           "$ref": "#/definitions/v1TraceConfig",
+          "additionalProperties": null,
           "description": "Requested updated configuration."
         }
-      }
+      },
+      "additionalProperties": null
     }
   }
 }

--- a/src/install-protoc.sh
+++ b/src/install-protoc.sh
@@ -13,7 +13,7 @@ readonly PROTOC_GEN_GO_URL="https://github.com/protocolbuffers/protobuf-go/relea
 readonly PROTOC_GEN_GO_GRPC_VER="v1.30.0"
 readonly PROTOC_GEN_GO_GRPC_REPO_URL="https://github.com/grpc/grpc-go"
 
-readonly GRPC_ECOSYSTEM_VER="v1.14.6"
+readonly GRPC_ECOSYSTEM_VER="v2.4.0"
 readonly GRPC_ECOSYSTEM_URL="https://github.com/grpc-ecosystem/grpc-gateway/releases/download/${GRPC_ECOSYSTEM_VER}"
 
 readonly PROTOC_GEN_SWAGGER_BIN="protoc-gen-swagger-${GRPC_ECOSYSTEM_VER}-linux-$( uname -m )"


### PR DESCRIPTION
gRPC Gateway went through a major rewrite to v2 last year. The main impact that I see on this repo is the protobuf annotation changes from swagger to openapiv2 and of course the protoc plugin was renamed as well. I'll take care of those in this PR.

Ref: https://grpc-ecosystem.github.io/grpc-gateway/docs/development/grpc-gateway_v2_migration_guide/

